### PR TITLE
NSX-4: use cfy_exc.RecoverableError in delete functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,58 @@ Cloudify Network Virtualization with VMware (NSX) plugin
 # Check platform example
 ```
 
-export NSX_IP="<nsx_ip>"
-export NSX_USER="<nsx_user>"
-export NSX_PASSWORD="<nsx_password>"
-export NODE_NAME_PREFIX="<some_free_prefix_for_objects>"
-
 # get plugin codebase
 git clone https://github.com/cloudify-cosmo/cloudify-nsx-plugin.git
 
 # install plugin localy
 pip install -e cloudify-nsx-plugin/
 pip install -r cloudify-nsx-plugin/test-requirements.txt
+
+# inputs for platform tests
+export NSX_IP="<nsx_ip>"
+export NSX_USER="<nsx_user>"
+export NSX_PASSWORD="<nsx_password>"
+export NODE_NAME_PREFIX="<some_free_prefix_for_objects>"
+
+# cleanup previous results
+rm .coverage -rf
+
+# check state
+nosetests -v --with-coverage --cover-package=cloudify_nsx cloudify-nsx-plugin/tests/platformtests/ cloudify-nsx-plugin/tests/unittests/
+
+```
+# Check total coverage and full functionality
+```
+
+# get plugin codebase
+git clone https://github.com/cloudify-cosmo/cloudify-nsx-plugin.git
+git clone https://github.com/cloudify-cosmo/cloudify-vsphere-plugin.git
+
+# install plugin localy
+pip install -e cloudify-nsx-plugin/
+pip install -r cloudify-nsx-plugin/test-requirements.txt
+
+cd cloudify-vsphere-plugin/ && git checkout 2.3.0-m1 && cd ..
+pip install -e cloudify-vsphere-plugin/
+pip install -r cloudify-vsphere-plugin/test-requirements.txt
+
+# inputs for platform tests
+# NSX
+export NSX_IP="<nsx_ip>"
+export NSX_USER="<nsx_user>"
+export NSX_PASSWORD="<nsx_password>"
+# VCENTER
+export VCENTER_IP="<vcenter_ip>"
+export VCENTER_USER="<vcenter_user>"
+export VCENTER_PASSWORD="<vcenter_password>"
+# optional
+export VCENTER_DATASTORE="<vcenter_datastore>"
+export VCENTER_DATACENTER="<vcenter_datacenter>"
+export VCENTER_TEMPLATE="<vcenter_linux_template>"
+export VCENTER_CLUSTER="<vcenter_cluster>"
+export VCENTER_RESOURCE_POOL="<vcenter_resource_pool>"
+# prefixes
+export NODE_NAME_PREFIX="<some_free_prefix_for_objects>"
 
 # cleanup previous results
 rm .coverage -rf

--- a/cloudify_nsx/library/nsx_common.py
+++ b/cloudify_nsx/library/nsx_common.py
@@ -236,22 +236,6 @@ def check_raw_result(result_raw):
         )
 
 
-def get_logical_switch(client_session, logical_switch_id):
-    raw_result = client_session.read('logicalSwitch', uri_parameters={
-        'virtualWireID': logical_switch_id
-    })
-    check_raw_result(raw_result)
-    return raw_result['body']['virtualWire']
-
-
-def get_edgegateway(client_session, edgeId):
-    raw_result = client_session.read('nsxEdge', uri_parameters={
-        'edgeId': edgeId
-    })
-    check_raw_result(raw_result)
-    return raw_result['body']['edge']
-
-
 def all_relationships_are_present(relationships,
                                   expected_relationships):
     relationships = [relationship.type for relationship in relationships]

--- a/cloudify_nsx/library/nsx_common.py
+++ b/cloudify_nsx/library/nsx_common.py
@@ -164,10 +164,8 @@ def get_properties(name, kwargs):
     return use_existing, properties_dict
 
 
-def get_properties_and_validate(name, kwargs, validate_dict=None):
+def get_properties_and_validate(name, kwargs, validate_dict):
     use_existing, properties_dict = get_properties(name, kwargs)
-    if not validate_dict:
-        validate_dict = {}
     ctx.logger.info("checking %s: %s" % (name, str(properties_dict)))
     return use_existing, _validate(
         properties_dict, validate_dict, use_existing
@@ -210,7 +208,7 @@ def nsx_login(kwargs):
 
 
 def check_raw_result(result_raw):
-    if result_raw['status'] < 200 and result_raw['status'] >= 300:
+    if result_raw['status'] < 200 or result_raw['status'] >= 300:
         ctx.logger.error("Status %s" % result_raw['status'])
         raise cfy_exc.NonRecoverableError(
             "We have error with request."

--- a/cloudify_nsx/library/nsx_esg_dlr.py
+++ b/cloudify_nsx/library/nsx_esg_dlr.py
@@ -17,6 +17,14 @@ from cloudify import exceptions as cfy_exc
 from cloudify import ctx
 
 
+def get_edgegateway(client_session, edgeId):
+    raw_result = client_session.read('nsxEdge', uri_parameters={
+        'edgeId': edgeId
+    })
+    common.check_raw_result(raw_result)
+    return raw_result['body']['edge']
+
+
 def dlr_add_interface(client_session, dlr_id, interface_ls_id, interface_ip,
                       interface_subnet, name=None, vnic=None):
     """

--- a/cloudify_nsx/library/nsx_esg_dlr.py
+++ b/cloudify_nsx/library/nsx_esg_dlr.py
@@ -191,6 +191,13 @@ def update_dhcp_relay(client_session, esg_id, relayServer=None,
     common.check_raw_result(raw_result)
 
 
+def del_dhcp_relay(client_session, resource_id):
+    raw_result = client_session.delete('dhcpRelay', uri_parameters={
+        'edgeId': resource_id
+    })
+    common.check_raw_result(raw_result)
+
+
 def routing_global_config(client_session, esg_id, enabled,
                           routingGlobalConfig=None, staticRouting=None):
 
@@ -362,9 +369,16 @@ def add_bgp_neighbour(client_session, esg_id, use_existing, ipAddress,
     )
 
 
-def del_bgp_neighbour(client_session, neighbour_id):
+def del_edge(client_session, resource_id):
+    raw_result = client_session.delete('nsxEdge', uri_parameters={
+        'edgeId': resource_id
+    })
+    common.check_raw_result(raw_result)
 
-    ids = neighbour_id.split("|")
+
+def del_bgp_neighbour(client_session, resource_id):
+
+    ids = resource_id.split("|")
 
     esg_id, ipAddress, remoteAS, protocolAddress, forwardingAddress = ids
 
@@ -926,7 +940,7 @@ def esg_cfg_interface(client_session, esg_id, ifindex, ipaddr=None,
     common.check_raw_result(cfg_result)
 
 
-def esg_clear_interface(client_session, esg_id, ifindex):
+def esg_clear_interface(client_session, esg_id, resource_id):
     """
     This function resets the vnic configuration of an ESG to its default
       state
@@ -936,12 +950,12 @@ def esg_clear_interface(client_session, esg_id, ifindex):
     :return: Returns True on successful configuration of the Interface
     """
     vnic_config = client_session.read(
-        'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id}
+        'vnic', uri_parameters={'index': resource_id, 'edgeId': esg_id}
     )['body']
 
     vnic_config['vnic']['mtu'] = '1500'
     vnic_config['vnic']['type'] = 'internal'
-    vnic_config['vnic']['name'] = 'vnic{}'.format(ifindex)
+    vnic_config['vnic']['name'] = 'vnic{}'.format(resource_id)
     vnic_config['vnic']['addressGroups'] = None
     vnic_config['vnic']['portgroupId'] = None
     vnic_config['vnic']['portgroupName'] = None
@@ -950,7 +964,7 @@ def esg_clear_interface(client_session, esg_id, ifindex):
     vnic_config['vnic']['isConnected'] = 'false'
 
     cfg_result = client_session.update(
-        'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id},
+        'vnic', uri_parameters={'index': resource_id, 'edgeId': esg_id},
         request_body_dict=vnic_config)
     common.check_raw_result(cfg_result)
 
@@ -1807,7 +1821,7 @@ def add_vm_binding(client_session, esg_id, vm_id, vnic_id, hostname, ip,
     return result['objectId']
 
 
-def delete_dhcp_binding(client_session, esg_id, binding_id):
+def delete_dhcp_binding(client_session, esg_id, resource_id):
     """
     This function deletes a DHCP binding from an edge DHCP Server
 
@@ -1824,7 +1838,7 @@ def delete_dhcp_binding(client_session, esg_id, binding_id):
 
     result = client_session.delete(
         'dhcpStaticBindingID',
-        uri_parameters={'edgeId': esg_id, 'bindingID': binding_id}
+        uri_parameters={'edgeId': esg_id, 'bindingID': resource_id}
     )
 
     common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_firewall.py
+++ b/cloudify_nsx/library/nsx_firewall.py
@@ -70,7 +70,4 @@ def delete_firewall_rule(client_session, esg_id, resource_id):
             'edgeId': esg_id, 'ruleId': resource_id
         })
 
-    if result['status'] == 204:
-        return True
-    else:
-        return None
+    common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_lswitch.py
+++ b/cloudify_nsx/library/nsx_lswitch.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import nsx_common as common
+
+
+def get_logical_switch(client_session, logical_switch_id):
+    raw_result = client_session.read('logicalSwitch', uri_parameters={
+        'virtualWireID': logical_switch_id
+    })
+    common.check_raw_result(raw_result)
+    return raw_result['body']['virtualWire']
+
+
+def del_logical_switch(client_session, resource_id):
+    raw_result = client_session.delete(
+        'logicalSwitch', uri_parameters={'virtualWireID': resource_id}
+    )
+    common.check_raw_result(raw_result)

--- a/cloudify_nsx/library/nsx_nat.py
+++ b/cloudify_nsx/library/nsx_nat.py
@@ -31,17 +31,12 @@ def nat_service(client_session, esg_id, enabled):
             new_nat_config['nat']['enabled'] = 'false'
             change_needed = True
 
-    if not change_needed:
-        return True
-    else:
+    if change_needed:
         result = client_session.update(
             'edgeNat', uri_parameters={'edgeId': esg_id},
             request_body_dict=new_nat_config
         )
-        if result['status'] == 204:
-            return True
-        else:
-            return False
+        common.check_raw_result(result)
 
 
 def add_nat_rule(client_session, esg_id, action, originalAddress,
@@ -90,8 +85,4 @@ def delete_nat_rule(client_session, esg_id, resource_id):
     result = client_session.delete(
         'edgeNatRule', uri_parameters={'edgeId': esg_id, 'ruleID': resource_id}
     )
-
-    if result['status'] == 204:
-        return True
-    else:
-        return None
+    common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_security_tag.py
+++ b/cloudify_nsx/library/nsx_security_tag.py
@@ -64,11 +64,7 @@ def delete_tag(client_session, securityid):
         'securityTagID',
         uri_parameters={'tagId': securityid}
     )
-
-    if result['status'] == 204:
-        return True
-    else:
-        return None
+    common.check_raw_result(result)
 
 
 def add_tag_vm(client_session, tag_id, vm_id):

--- a/cloudify_nsx/library/nsx_security_tag.py
+++ b/cloudify_nsx/library/nsx_security_tag.py
@@ -59,10 +59,10 @@ def add_tag(client_session, name, description):
     return result_raw['objectId']
 
 
-def delete_tag(client_session, securityid):
+def delete_tag(client_session, resource_id):
     result = client_session.delete(
         'securityTagID',
-        uri_parameters={'tagId': securityid}
+        uri_parameters={'tagId': resource_id}
     )
     common.check_raw_result(result)
 

--- a/cloudify_nsx/network/bgp_neighbour_filter.py
+++ b/cloudify_nsx/network/bgp_neighbour_filter.py
@@ -16,6 +16,7 @@ from cloudify import ctx
 from cloudify.decorators import operation
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
+from cloudify import exceptions as cfy_exc
 
 
 @operation
@@ -98,10 +99,16 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    cfy_dlr.del_bgp_neighbour_filter(
-        client_session,
-        resource_id
-    )
+    try:
+        cfy_dlr.del_bgp_neighbour_filter(
+            client_session,
+            resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/dhcp_bind.py
+++ b/cloudify_nsx/network/dhcp_bind.py
@@ -133,11 +133,14 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    if not nsx_dhcp.delete_dhcp_binding(client_session,
-                                        bind_dict['esg_id'],
-                                        resource_id):
-        raise cfy_exc.NonRecoverableError(
-            "Can't drop dhcp bind"
+    try:
+        nsx_dhcp.delete_dhcp_binding(client_session,
+                                     bind_dict['esg_id'],
+                                     resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
         )
 
     ctx.logger.info("deleted %s" % resource_id)

--- a/cloudify_nsx/network/dhcp_bind.py
+++ b/cloudify_nsx/network/dhcp_bind.py
@@ -133,15 +133,12 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_dhcp.delete_dhcp_binding(client_session,
-                                     bind_dict['esg_id'],
-                                     resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_dhcp.delete_dhcp_binding,
+        client_session=client_session,
+        esg_id=bind_dict['esg_id'],
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/dhcp_pool.py
+++ b/cloudify_nsx/network/dhcp_pool.py
@@ -99,11 +99,14 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    if not nsx_dhcp.delete_dhcp_pool(client_session,
-                                     pool_dict['esg_id'],
-                                     resource_id):
-        raise cfy_exc.NonRecoverableError(
-            "Can't drop dhcp pool"
+    try:
+        nsx_dhcp.delete_dhcp_pool(client_session,
+                                  pool_dict['esg_id'],
+                                  resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
         )
 
     ctx.logger.info("deleted %s" % resource_id)

--- a/cloudify_nsx/network/dlr.py
+++ b/cloudify_nsx/network/dlr.py
@@ -121,15 +121,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        client_session.delete('nsxEdge', uri_parameters={
-            'edgeId': resource_id
-        })
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_dlr.del_edge,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/dlr.py
+++ b/cloudify_nsx/network/dlr.py
@@ -121,7 +121,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    client_session.delete('nsxEdge', uri_parameters={'edgeId': resource_id})
+    try:
+        client_session.delete('nsxEdge', uri_parameters={
+            'edgeId': resource_id
+        })
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/dlr_bgp_neighbour.py
+++ b/cloudify_nsx/network/dlr_bgp_neighbour.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -22,8 +23,6 @@ def _create(kwargs, validation_rules):
     use_existing, neighbour = common.get_properties_and_validate(
         'neighbour', kwargs, validation_rules
     )
-
-    print use_existing, neighbour
 
     if use_existing:
         ctx.logger.info("Used existed, no changes made")
@@ -118,10 +117,16 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    cfy_dlr.del_bgp_neighbour(
-        client_session,
-        resource_id
-    )
+    try:
+        cfy_dlr.del_bgp_neighbour(
+            client_session,
+            resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/dlr_bgp_neighbour.py
+++ b/cloudify_nsx/network/dlr_bgp_neighbour.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -117,16 +116,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        cfy_dlr.del_bgp_neighbour(
-            client_session,
-            resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_bgp_neighbour,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/dlr_interface.py
+++ b/cloudify_nsx/network/dlr_interface.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import pynsxv.library.nsx_dlr as nsx_router
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
@@ -89,13 +90,19 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    result_raw = nsx_router.dlr_del_interface(
-        client_session,
-        ctx.instance.runtime_properties['resource_dlr_id'],
-        resource_id
-    )
+    try:
+        result_raw = nsx_router.dlr_del_interface(
+            client_session,
+            ctx.instance.runtime_properties['resource_dlr_id'],
+            resource_id
+        )
 
-    common.check_raw_result(result_raw)
+        common.check_raw_result(result_raw)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/dlr_interface.py
+++ b/cloudify_nsx/network/dlr_interface.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import pynsxv.library.nsx_dlr as nsx_router
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
@@ -90,19 +89,20 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
+    def dlr_del_interface(client_session, dlr_id, resource_id):
         result_raw = nsx_router.dlr_del_interface(
             client_session,
-            ctx.instance.runtime_properties['resource_dlr_id'],
+            dlr_id,
             resource_id
         )
-
         common.check_raw_result(result_raw)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+
+    common.attempt_with_rerun(
+        dlr_del_interface,
+        client_session=client_session,
+        dlr_id=ctx.instance.runtime_properties['resource_dlr_id'],
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg.py
+++ b/cloudify_nsx/network/esg.py
@@ -124,15 +124,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        client_session.delete('nsxEdge', uri_parameters={
-            'edgeId': resource_id
-        })
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_dlr.del_edge,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg.py
+++ b/cloudify_nsx/network/esg.py
@@ -67,7 +67,7 @@ def create(**kwargs):
     client_session = common.nsx_login(kwargs)
 
     if use_existing and resource_id:
-        name = common.get_edgegateway(client_session, resource_id)['name']
+        name = nsx_dlr.get_edgegateway(client_session, resource_id)['name']
         edge_dict['name'] = name
         ctx.instance.runtime_properties['edge']['name'] = name
 

--- a/cloudify_nsx/network/esg.py
+++ b/cloudify_nsx/network/esg.py
@@ -124,9 +124,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    ctx.logger.info("checking %s" % resource_id)
-
-    client_session.delete('nsxEdge', uri_parameters={'edgeId': resource_id})
+    try:
+        client_session.delete('nsxEdge', uri_parameters={
+            'edgeId': resource_id
+        })
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg_firewall.py
+++ b/cloudify_nsx/network/esg_firewall.py
@@ -129,17 +129,12 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_firewall.delete_firewall_rule(
-            client_session,
-            nat_dict['esg_id'],
-            resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_firewall.delete_firewall_rule,
+        client_session=client_session,
+        esg_id=nat_dict['esg_id'],
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg_firewall.py
+++ b/cloudify_nsx/network/esg_firewall.py
@@ -129,15 +129,16 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    result_raw = nsx_firewall.delete_firewall_rule(
-        client_session,
-        nat_dict['esg_id'],
-        resource_id
-    )
-    if not result_raw:
-        ctx.logger.error("Status %s" % result_raw['status'])
-        raise cfy_exc.NonRecoverableError(
-            "Can't delete interface."
+    try:
+        nsx_firewall.delete_firewall_rule(
+            client_session,
+            nat_dict['esg_id'],
+            resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
         )
 
     ctx.logger.info("delete %s" % resource_id)

--- a/cloudify_nsx/network/esg_interface.py
+++ b/cloudify_nsx/network/esg_interface.py
@@ -16,7 +16,6 @@ from cloudify import ctx
 from cloudify.decorators import operation
 import cloudify_nsx.library.nsx_esg_dlr as nsx_esg
 import cloudify_nsx.library.nsx_common as common
-from cloudify import exceptions as cfy_exc
 
 
 @operation
@@ -123,17 +122,12 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_esg.esg_clear_interface(
-            client_session,
-            interface['esg_id'],
-            resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_esg.esg_clear_interface,
+        client_session=client_session,
+        esg_id=interface['esg_id'],
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg_nat.py
+++ b/cloudify_nsx/network/esg_nat.py
@@ -118,17 +118,12 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_nat.delete_nat_rule(
-            client_session,
-            nat_dict['esg_id'],
-            resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_nat.delete_nat_rule,
+        client_session=client_session,
+        esg_id=nat_dict['esg_id'],
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/esg_nat.py
+++ b/cloudify_nsx/network/esg_nat.py
@@ -118,15 +118,16 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    result_raw = nsx_nat.delete_nat_rule(
-        client_session,
-        nat_dict['esg_id'],
-        resource_id
-    )
-    if not result_raw:
-        ctx.logger.error("Status %s" % result_raw['status'])
-        raise cfy_exc.NonRecoverableError(
-            "Can't delete interface."
+    try:
+        nsx_nat.delete_nat_rule(
+            client_session,
+            nat_dict['esg_id'],
+            resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
         )
 
     ctx.logger.info("delete %s" % resource_id)

--- a/cloudify_nsx/network/lswitch.py
+++ b/cloudify_nsx/network/lswitch.py
@@ -16,6 +16,7 @@ from cloudify import ctx
 from cloudify.decorators import operation
 import cloudify_nsx.library.nsx_common as common
 import pynsxv.library.nsx_logical_switch as nsx_logical_switch
+import cloudify_nsx.library.nsx_lswitch as nsx_lswitch
 from cloudify import exceptions as cfy_exc
 
 
@@ -88,8 +89,8 @@ def create(**kwargs):
     if not ctx.instance.runtime_properties.get('resource_dvportgroup_id'):
         # read additional info about switch
         if not switch_params:
-            switch_params = common.get_logical_switch(client_session,
-                                                      resource_id)
+            switch_params = nsx_lswitch.get_logical_switch(client_session,
+                                                           resource_id)
 
         dpg_id = switch_params.get(
             'vdsContextWithBacking', {}
@@ -123,14 +124,8 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    def del_logical_switch(client_session, resource_id):
-        raw_result = client_session.delete(
-            'logicalSwitch', uri_parameters={'virtualWireID': resource_id}
-        )
-        common.check_raw_result(raw_result)
-
     common.attempt_with_rerun(
-        del_logical_switch,
+        nsx_lswitch.del_logical_switch,
         client_session=client_session,
         resource_id=resource_id
     )

--- a/cloudify_nsx/network/lswitch.py
+++ b/cloudify_nsx/network/lswitch.py
@@ -123,15 +123,17 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        client_session.delete(
+    def del_logical_switch(client_session, resource_id):
+        raw_result = client_session.delete(
             'logicalSwitch', uri_parameters={'virtualWireID': resource_id}
         )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+        common.check_raw_result(raw_result)
+
+    common.attempt_with_rerun(
+        del_logical_switch,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/lswitch.py
+++ b/cloudify_nsx/network/lswitch.py
@@ -123,9 +123,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    client_session.delete(
-        'logicalSwitch', uri_parameters={'virtualWireID': resource_id}
-    )
+    try:
+        client_session.delete(
+            'logicalSwitch', uri_parameters={'virtualWireID': resource_id}
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/ospf_area.py
+++ b/cloudify_nsx/network/ospf_area.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -96,13 +95,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        cfy_dlr.del_esg_ospf_area(client_session, resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_esg_ospf_area,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/ospf_area.py
+++ b/cloudify_nsx/network/ospf_area.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -95,10 +96,13 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    cfy_dlr.del_esg_ospf_area(
-        client_session,
-        resource_id
-    )
+    try:
+        cfy_dlr.del_esg_ospf_area(client_session, resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/ospf_interface.py
+++ b/cloudify_nsx/network/ospf_interface.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -94,16 +93,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        cfy_dlr.del_esg_ospf_interface(
-            client_session,
-            ctx.instance.runtime_properties['resource_id']
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_esg_ospf_interface,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/relay.py
+++ b/cloudify_nsx/network/relay.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -74,15 +73,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        client_session.delete('dhcpRelay', uri_parameters={
-            'edgeId': resource_id
-        })
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_dhcp_relay,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/network/routing_ip_prefix.py
+++ b/cloudify_nsx/network/routing_ip_prefix.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -72,13 +71,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        cfy_dlr.del_routing_prefix(client_session, resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_routing_prefix,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/routing_ip_prefix.py
+++ b/cloudify_nsx/network/routing_ip_prefix.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -71,10 +72,13 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    cfy_dlr.del_routing_prefix(
-        client_session,
-        resource_id
-    )
+    try:
+        cfy_dlr.del_routing_prefix(client_session, resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/routing_redistribution.py
+++ b/cloudify_nsx/network/routing_redistribution.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -109,10 +110,13 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    cfy_dlr.del_routing_rule(
-        client_session,
-        resource_id
-    )
+    try:
+        cfy_dlr.del_routing_rule(client_session, resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/network/routing_redistribution.py
+++ b/cloudify_nsx/network/routing_redistribution.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_esg_dlr as cfy_dlr
 import cloudify_nsx.library.nsx_common as common
 
@@ -110,13 +109,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        cfy_dlr.del_routing_rule(client_session, resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        cfy_dlr.del_routing_rule,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/security/group.py
+++ b/cloudify_nsx/security/group.py
@@ -96,13 +96,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_group.del_group(client_session, resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_group.del_group,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group.py
+++ b/cloudify_nsx/security/group.py
@@ -96,10 +96,13 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_group.del_group(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_group.del_group(client_session, resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group_dynamic_member.py
+++ b/cloudify_nsx/security/group_dynamic_member.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_group as nsx_security_group
 import cloudify_nsx.library.nsx_common as common
 
@@ -73,10 +74,13 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_group.del_dynamic_member(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_group.del_dynamic_member(client_session, resource_id)
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group_dynamic_member.py
+++ b/cloudify_nsx/security/group_dynamic_member.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_group as nsx_security_group
 import cloudify_nsx.library.nsx_common as common
 
@@ -74,13 +73,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_group.del_dynamic_member(client_session, resource_id)
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_group.del_dynamic_member,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group_exclude_member.py
+++ b/cloudify_nsx/security/group_exclude_member.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_group as nsx_security_group
 import cloudify_nsx.library.nsx_common as common
 
@@ -72,15 +71,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_group.del_group_exclude_member(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_group.del_group_exclude_member,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group_member.py
+++ b/cloudify_nsx/security/group_member.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_group as nsx_security_group
 import cloudify_nsx.library.nsx_common as common
 
@@ -71,15 +70,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_group.del_group_member(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_group.del_group_member,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/group_member.py
+++ b/cloudify_nsx/security/group_member.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_group as nsx_security_group
 import cloudify_nsx.library.nsx_common as common
 
@@ -70,10 +71,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_group.del_group_member(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_group.del_group_member(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy.py
+++ b/cloudify_nsx/security/policy.py
@@ -111,15 +111,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_policy.del_policy(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_policy.del_policy,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy.py
+++ b/cloudify_nsx/security/policy.py
@@ -111,10 +111,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_policy.del_policy(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_policy.del_policy(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy_group_bind.py
+++ b/cloudify_nsx/security/policy_group_bind.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_policy as nsx_security_policy
 import cloudify_nsx.library.nsx_common as common
 
@@ -72,15 +71,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_policy.del_policy_group_bind(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_policy.del_policy_group_bind,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy_group_bind.py
+++ b/cloudify_nsx/security/policy_group_bind.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_policy as nsx_security_policy
 import cloudify_nsx.library.nsx_common as common
 
@@ -71,10 +72,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_policy.del_policy_group_bind(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_policy.del_policy_group_bind(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy_section.py
+++ b/cloudify_nsx/security/policy_section.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_policy as nsx_security_policy
 import cloudify_nsx.library.nsx_common as common
 
@@ -76,15 +75,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_policy.del_policy_section(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_policy.del_policy_section,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/policy_section.py
+++ b/cloudify_nsx/security/policy_section.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_policy as nsx_security_policy
 import cloudify_nsx.library.nsx_common as common
 
@@ -75,10 +76,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_policy.del_policy_section(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_policy.del_policy_section(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/tag.py
+++ b/cloudify_nsx/security/tag.py
@@ -81,10 +81,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_tag.delete_tag(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_tag.delete_tag(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/tag.py
+++ b/cloudify_nsx/security/tag.py
@@ -81,15 +81,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_tag.delete_tag(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_tag.delete_tag,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("delete %s" % resource_id)
 

--- a/cloudify_nsx/security/tag_vm.py
+++ b/cloudify_nsx/security/tag_vm.py
@@ -14,6 +14,7 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
+from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_tag as nsx_security_tag
 import cloudify_nsx.library.nsx_common as common
 
@@ -67,10 +68,15 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    nsx_security_tag.delete_tag_vm(
-        client_session,
-        resource_id
-    )
+    try:
+        nsx_security_tag.delete_tag_vm(
+            client_session, resource_id
+        )
+    except Exception as ex:
+        ctx.logger.error("We have issue with remove: %s", str(ex))
+        raise cfy_exc.RecoverableError(
+            message="Retry to delete little later", retry_after=30
+        )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/cloudify_nsx/security/tag_vm.py
+++ b/cloudify_nsx/security/tag_vm.py
@@ -14,7 +14,6 @@
 #    * limitations under the License.
 from cloudify import ctx
 from cloudify.decorators import operation
-from cloudify import exceptions as cfy_exc
 import cloudify_nsx.library.nsx_security_tag as nsx_security_tag
 import cloudify_nsx.library.nsx_common as common
 
@@ -68,15 +67,11 @@ def delete(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    try:
-        nsx_security_tag.delete_tag_vm(
-            client_session, resource_id
-        )
-    except Exception as ex:
-        ctx.logger.error("We have issue with remove: %s", str(ex))
-        raise cfy_exc.RecoverableError(
-            message="Retry to delete little later", retry_after=30
-        )
+    common.attempt_with_rerun(
+        nsx_security_tag.delete_tag_vm,
+        client_session=client_session,
+        resource_id=resource_id
+    )
 
     ctx.logger.info("deleted %s" % resource_id)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@ plugins:
     executor: central_deployment_agent
     source: https://github.com/cloudify-cosmo/cloudify-nsx-plugin/archive/master.zip
     package_name: cloudify-nsx-plugin
-    package_version: '3.4a1'
+    package_version: '1.0'
 
 data_types:
 
@@ -13,10 +13,10 @@ data_types:
         default: administrator@vsphere.local
         required: true
       password:
-        default: vcenter
+        default: vsphere
         required: true
       host:
-        default: vcenter.local
+        default: vsphere.local
         required: true
       raml:
         default: ''

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-nsx-plugin',
-    version='3.4a1',
+    version='1.0',
     description='support vmware nsx',
     author='Denis Pauk',
     author_email='pauk.denis@gmail.com',

--- a/tests/integration/resources/dlr_functionality.yaml
+++ b/tests/integration/resources/dlr_functionality.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - ../plugin.yaml
+  - ../../../plugin.yaml
   - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-vsphere-plugin/2.3.0-m1/plugin.yaml
 
 inputs:
@@ -73,6 +73,16 @@ inputs:
        vcenter datacenter
     default: Datacenter
 
+  vcenter_resource_pool:
+    description: >
+      Resource pool name
+    default: Resources
+
+  template_name:
+    description: >
+      Template to clone VMs from
+    default: CentOS-7.2-x86_64-1511-tmpl
+
 node_types:
   connection_configuration:
      derived_from: cloudify.nodes.Root
@@ -89,7 +99,7 @@ node_templates:
         host: { get_input: vcenter_ip }
         port: 443
         datacenter_name: { get_input: vcenter_datacenter }
-        resource_pool_name: Resources
+        resource_pool_name: { get_input: vcenter_resource_pool }
         auto_placement: true
 
   datacenter:
@@ -127,6 +137,16 @@ node_templates:
         # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
         mode: UNICAST_MODE
 
+  slave_lswith:
+    type: cloudify.nsx.lswitch
+    properties:
+      nsx_auth: *nsx_auth
+      switch:
+        name: {concat:[{get_input: node_name_prefix}, slave_swith]}
+        transport_zone: Main_Zone
+        # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
+        mode: UNICAST_MODE
+
   nsx_dlr:
     type: cloudify.nsx.dlr
     properties:
@@ -157,10 +177,10 @@ node_templates:
           defaultRoute:
             # some address, will be replaced by default gateway
             gatewayAddress: 192.168.1.43
-      bgp:
+      ospf:
         enabled: true
-        localAS: 64520
-        redistribution: true
+        protocolAddress: 192.168.1.44
+        forwardingAddress: 192.168.1.11
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
@@ -181,79 +201,123 @@ node_templates:
       - type: cloudify.nsx.relationships.deployed_on_cluster
         target: cluster
 
-  bgp_neighbour:
-    type: cloudify.nsx.dlrBGPNeighbour
+  interface:
+    type: cloudify.nsx.dlr_interface
     properties:
       nsx_auth: *nsx_auth
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            neighbour:
+            interface:
               dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              ipAddress: 192.168.2.1
-              remoteAS: 64521
-              protocolAddress: 192.168.1.20
-              forwardingAddress: 192.168.1.11
+              interface_ls_id: { get_attribute: [ slave_lswith, resource_id ] }
+              interface_ip: 192.168.2.11
+              interface_subnet: 255.255.255.0
+              name: {concat:[{get_input: node_name_prefix}, router_interface]}
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: nsx_dlr
+      - type: cloudify.relationships.connected_to
+        target: slave_lswith
+
+  ospf_areas:
+    type: cloudify.nsx.ospf_areas
+    properties:
+      nsx_auth: *nsx_auth
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            area:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              areaId: 1000
+              type: nssa
+              authentication:
+                type: none
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: nsx_dlr
+      - type: cloudify.relationships.connected_to
+        target: interface
+
+  ospf_interface:
+    type: cloudify.nsx.ospf_interfaces
+    properties:
+      nsx_auth: *nsx_auth
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            interface:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              vnic: { get_attribute: [ nsx_dlr, router, uplink_vnic ] }
+              areaId: { get_attribute: [ ospf_areas, area, areaId ] }
+              helloInterval: 10
+              priority: 128
+              cost: 1
+              deadInterval: 40
+              mtuIgnore: false
+    relationships:
+      - type: cloudify.relationships.connected_to
+        target: ospf_areas
+      - type: cloudify.relationships.connected_to
+        target: interface
+      - type: cloudify.relationships.contained_in
+        target: nsx_dlr
+
+  dlr_static_gateway:
+    type: cloudify.nsx.dlr_dgw
+    properties:
+      nsx_auth: *nsx_auth
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            gateway:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              address: 192.168.1.12
     relationships:
       - type: cloudify.relationships.contained_in
         target: nsx_dlr
 
-  bgp_neighbour_filter:
-    type: cloudify.nsx.esgBGPNeighbourFilter
+  dhcp_relay:
+    type: cloudify.nsx.dlr_dhcp_relay
     properties:
       nsx_auth: *nsx_auth
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            filter:
-              neighbour_id: { get_attribute: [ bgp_neighbour, resource_id ] }
-              action: deny
-              ipPrefixGe: 30
-              ipPrefixLe': 32
-              direction: in
-              network: 192.169.1.0/24
-    relationships:
-      - type: cloudify.relationships.contained_in
-        target: bgp_neighbour
-
-  dlr_ip_prefix:
-    type: cloudify.nsx.dlr_routing_ip_prefix
-    properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            prefix:
+            relay:
               dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              name: {concat:[{get_input: node_name_prefix}, routing_prefix]}
-              ipAddress: 10.112.196.160/24
+              relayServer:
+                ipAddress: 8.8.8.8
+              relayAgents:
+                relayAgent:
+                  vnicIndex: { get_attribute: [ interface, resource_id ] }
+                  giAddress: { get_attribute: [ interface, interface, interface_ip ] }
     relationships:
       - type: cloudify.relationships.contained_in
         target: nsx_dlr
+      - type: cloudify.relationships.connected_to
+        target: interface
 
-  dlr_bgp_redistribute:
-    type: cloudify.nsx.routing_redistribution_rule
+  testserver:
+    type: cloudify.vsphere.nodes.Server
     properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            rule:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              prefixName: { get_attribute: [ dlr_ip_prefix, prefix, name ] }
-              type: bgp
-              from:
-                ospf: true
-                static: true
-              action: deny
+      install_agent: false
+      server:
+        name: {concat:[{get_input: node_name_prefix}, connecttonsxnet]}
+        template: { get_input: template_name }
+        cpus: 1
+        memory: 2048
+      connection_config: { get_property: [connection_configuration, connection_config] }
+      networking:
+        connect_networks:
+          - name: slave_lswith
+            from_relationship: true
+            switch_distributed: true
     relationships:
-      - type: cloudify.relationships.contained_in
-        target: nsx_dlr
-      - type: cloudify.relationships.depends_on
-        target: dlr_ip_prefix
-      - type: cloudify.relationships.depends_on
-        target: bgp_neighbour
+      - target: slave_lswith
+        type: cloudify.relationships.connected_to

--- a/tests/integration/resources/dlr_with_bgp_functionality.yaml
+++ b/tests/integration/resources/dlr_with_bgp_functionality.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - ../plugin.yaml
+  - ../../../plugin.yaml
   - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-vsphere-plugin/2.3.0-m1/plugin.yaml
 
 inputs:
@@ -73,6 +73,11 @@ inputs:
        vcenter datacenter
     default: Datacenter
 
+  vcenter_resource_pool:
+    description: >
+      Resource pool name
+    default: Resources
+
 node_types:
   connection_configuration:
      derived_from: cloudify.nodes.Root
@@ -89,7 +94,7 @@ node_templates:
         host: { get_input: vcenter_ip }
         port: 443
         datacenter_name: { get_input: vcenter_datacenter }
-        resource_pool_name: Resources
+        resource_pool_name: { get_input: vcenter_resource_pool }
         auto_placement: true
 
   datacenter:
@@ -127,14 +132,15 @@ node_templates:
         # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
         mode: UNICAST_MODE
 
-  esg:
-    type: cloudify.nsx.esg
+  nsx_dlr:
+    type: cloudify.nsx.dlr
     properties:
       nsx_auth: *nsx_auth
-      edge:
-        name: {concat:[{get_input: node_name_prefix}, real_edge]}
-        esg_pwd: SeCrEt010203!
-        esg_remote_access: true
+      router:
+        name: {concat:[{get_input: node_name_prefix}, some_router]}
+        dlr_pwd: SeCrEt010203!
+        # compact, large, quadlarge, xlarge
+        dlr_size: compact
       firewall:
         # accept or deny
         action: accept
@@ -144,16 +150,33 @@ node_templates:
         enabled: true
         syslog_enabled: false
         syslog_level: INFO
-      nat:
+      routing:
         enabled: true
+        routingGlobalConfig:
+          routerId: 192.168.1.11
+          logging:
+            logLevel: info
+            enable: false
+          ecmp: false
+        staticRouting:
+          defaultRoute:
+            # some address, will be replaced by default gateway
+            gatewayAddress: 192.168.1.43
+      bgp:
+        enabled: true
+        localAS: 64520
+        redistribution: true
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            edge:
-              default_pg: { get_attribute: [ master_lswith, vsphere_network_id ] }
+            router:
+              ha_ls_id: { get_attribute: [ master_lswith, resource_id ] }
+              uplink_ls_id: { get_attribute: [ master_lswith, resource_id ] }
+              uplink_ip: 192.168.1.11
+              uplink_subnet: 255.255.255.0
+              uplink_dgw: 192.168.1.1
     relationships:
-      # connected as network link
       - type: cloudify.relationships.connected_to
         target: master_lswith
       - type: cloudify.nsx.relationships.deployed_on_datacenter
@@ -163,142 +186,79 @@ node_templates:
       - type: cloudify.nsx.relationships.deployed_on_cluster
         target: cluster
 
-  slave_lswith:
-    type: cloudify.nsx.lswitch
+  bgp_neighbour:
+    type: cloudify.nsx.dlrBGPNeighbour
     properties:
       nsx_auth: *nsx_auth
-      switch:
-        name: {concat:[{get_input: node_name_prefix}, slave_swith]}
-        transport_zone: Main_Zone
-        # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
-        mode: UNICAST_MODE
-
-  esg_interface:
-    type: cloudify.nsx.esg_interface
-    properties:
-      nsx_auth: *nsx_auth
-      interface:
-        ifindex: 3
-        ipaddr: 192.168.3.1
-        netmask: 255.255.255.0
-        prefixlen: 24
-        name: {concat:[{get_input: node_name_prefix}, router_interface]}
-        mtu: 1500
-        is_connected: true
-        vnic_type: uplink
-        enable_send_redirects: true
-        enable_proxy_arp: true
-        secondary_ips: 192.168.3.128
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            interface:
-              esg_id: { get_attribute: [ esg, resource_id ] }
-              portgroup_id: { get_attribute: [ slave_lswith, resource_id ] }
+            neighbour:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              ipAddress: 192.168.2.1
+              remoteAS: 64521
+              protocolAddress: 192.168.1.20
+              forwardingAddress: 192.168.1.11
     relationships:
       - type: cloudify.relationships.contained_in
-        target: esg
-      - type: cloudify.relationships.connected_to
-        target: slave_lswith
+        target: nsx_dlr
 
-  esg_gateway:
-    type: cloudify.nsx.esg_gateway
+  bgp_neighbour_filter:
+    type: cloudify.nsx.esgBGPNeighbourFilter
     properties:
       nsx_auth: *nsx_auth
-      gateway:
-        dgw_ip: 192.168.3.11
-        vnic: 3
-        mtu: 1500
-        admin_distance: 1
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            gateway:
-              esg_id: { get_attribute: [ esg, resource_id ] }
+            filter:
+              neighbour_id: { get_attribute: [ bgp_neighbour, resource_id ] }
+              action: deny
+              ipPrefixGe: 30
+              ipPrefixLe': 32
+              direction: in
+              network: 192.169.1.0/24
     relationships:
       - type: cloudify.relationships.contained_in
-        target: esg
-      - type: cloudify.relationships.connected_to
-        target: esg_interface
+        target: bgp_neighbour
 
-  esg_reconfigure:
-    type: cloudify.nsx.esg
+  dlr_ip_prefix:
+    type: cloudify.nsx.dlr_routing_ip_prefix
     properties:
       nsx_auth: *nsx_auth
-      use_external_resource: true
-      routing:
-        enabled: true
-        routingGlobalConfig:
-          routerId: 192.168.3.11
-          logging:
-            logLevel: info
-            enable: false
-          ecmp: false
-      ospf:
-        enabled: true
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            resource_id: { get_attribute: [ esg, resource_id ] }
-        delete:
-          inputs:
-            routing:
-              enabled: true
-              routingGlobalConfig:
-                routerId: ""
-                logging:
-                  logLevel: info
-                  enable: false
-                ecmp: false
+            prefix:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              name: {concat:[{get_input: node_name_prefix}, routing_prefix]}
+              ipAddress: 10.112.196.160/24
     relationships:
-      # we need interface before change routering
+      - type: cloudify.relationships.contained_in
+        target: nsx_dlr
+
+  dlr_bgp_redistribute:
+    type: cloudify.nsx.routing_redistribution_rule
+    properties:
+      nsx_auth: *nsx_auth
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            rule:
+              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              prefixName: { get_attribute: [ dlr_ip_prefix, prefix, name ] }
+              type: bgp
+              from:
+                ospf: true
+                static: true
+              action: deny
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: nsx_dlr
       - type: cloudify.relationships.depends_on
-        target: esg_gateway
-
-  ospf_areas:
-    type: cloudify.nsx.ospf_areas
-    properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            area:
-              dlr_id: { get_attribute: [ esg_reconfigure, resource_id ] }
-              areaId: 1000
-              type: nssa
-              authentication:
-                type: none
-    relationships:
-      - type: cloudify.relationships.contained_in
-        target: esg_reconfigure
+        target: dlr_ip_prefix
       - type: cloudify.relationships.depends_on
-        target: esg_interface
-
-  ospf_interface:
-    type: cloudify.nsx.ospf_interfaces
-    properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            interface:
-              dlr_id: { get_attribute: [ esg_reconfigure, resource_id ] }
-              vnic: { get_attribute: [ esg_interface, resource_id ] }
-              areaId: { get_attribute: [ ospf_areas, area, areaId ] }
-              helloInterval: 10
-              priority: 128
-              cost: 1
-              deadInterval: 40
-              mtuIgnore: false
-    relationships:
-      - type: cloudify.relationships.connected_to
-        target: ospf_areas
-      - type: cloudify.relationships.depends_on
-        target: esg_interface
-      - type: cloudify.relationships.contained_in
-        target: esg
+        target: bgp_neighbour

--- a/tests/integration/resources/esg_functionality.yaml
+++ b/tests/integration/resources/esg_functionality.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - ../plugin.yaml
+  - ../../../plugin.yaml
   - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-vsphere-plugin/2.3.0-m1/plugin.yaml
 
 inputs:
@@ -73,6 +73,11 @@ inputs:
        vcenter datacenter
     default: Datacenter
 
+  vcenter_resource_pool:
+    description: >
+      Resource pool name
+    default: Resources
+
 node_types:
   connection_configuration:
      derived_from: cloudify.nodes.Root
@@ -89,7 +94,7 @@ node_templates:
         host: { get_input: vcenter_ip }
         port: 443
         datacenter_name: { get_input: vcenter_datacenter }
-        resource_pool_name: Resources
+        resource_pool_name: { get_input: vcenter_resource_pool }
         auto_placement: true
 
   datacenter:

--- a/tests/integration/resources/esg_with_ospf_functionality.yaml
+++ b/tests/integration/resources/esg_with_ospf_functionality.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - ../plugin.yaml
+  - ../../../plugin.yaml
   - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-vsphere-plugin/2.3.0-m1/plugin.yaml
 
 inputs:
@@ -73,10 +73,10 @@ inputs:
        vcenter datacenter
     default: Datacenter
 
-  template_name:
+  vcenter_resource_pool:
     description: >
-      Template to clone VMs from
-    default: CentOS-7.2-x86_64-1511-tmpl
+      Resource pool name
+    default: Resources
 
 node_types:
   connection_configuration:
@@ -94,7 +94,7 @@ node_templates:
         host: { get_input: vcenter_ip }
         port: 443
         datacenter_name: { get_input: vcenter_datacenter }
-        resource_pool_name: Resources
+        resource_pool_name: { get_input: vcenter_resource_pool }
         auto_placement: true
 
   datacenter:
@@ -132,6 +132,42 @@ node_templates:
         # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
         mode: UNICAST_MODE
 
+  esg:
+    type: cloudify.nsx.esg
+    properties:
+      nsx_auth: *nsx_auth
+      edge:
+        name: {concat:[{get_input: node_name_prefix}, real_edge]}
+        esg_pwd: SeCrEt010203!
+        esg_remote_access: true
+      firewall:
+        # accept or deny
+        action: accept
+        # true or false
+        logging: false
+      dhcp:
+        enabled: true
+        syslog_enabled: false
+        syslog_level: INFO
+      nat:
+        enabled: true
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            edge:
+              default_pg: { get_attribute: [ master_lswith, vsphere_network_id ] }
+    relationships:
+      # connected as network link
+      - type: cloudify.relationships.connected_to
+        target: master_lswith
+      - type: cloudify.nsx.relationships.deployed_on_datacenter
+        target: datacenter
+      - type: cloudify.nsx.relationships.deployed_on_datastore
+        target: datastore
+      - type: cloudify.nsx.relationships.deployed_on_cluster
+        target: cluster
+
   slave_lswith:
     type: cloudify.nsx.lswitch
     properties:
@@ -142,79 +178,90 @@ node_templates:
         # UNICAST_MODE, MULTYCAST_MODE, HYBRID_MODE
         mode: UNICAST_MODE
 
-  nsx_dlr:
-    type: cloudify.nsx.dlr
+  esg_interface:
+    type: cloudify.nsx.esg_interface
     properties:
       nsx_auth: *nsx_auth
-      router:
-        name: {concat:[{get_input: node_name_prefix}, some_router]}
-        dlr_pwd: SeCrEt010203!
-        # compact, large, quadlarge, xlarge
-        dlr_size: compact
-      firewall:
-        # accept or deny
-        action: accept
-        # true or false
-        logging: false
-      dhcp:
-        enabled: true
-        syslog_enabled: false
-        syslog_level: INFO
-      routing:
-        enabled: true
-        routingGlobalConfig:
-          routerId: 192.168.1.11
-          logging:
-            logLevel: info
-            enable: false
-          ecmp: false
-        staticRouting:
-          defaultRoute:
-            # some address, will be replaced by default gateway
-            gatewayAddress: 192.168.1.43
-      ospf:
-        enabled: true
-        protocolAddress: 192.168.1.44
-        forwardingAddress: 192.168.1.11
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            router:
-              ha_ls_id: { get_attribute: [ master_lswith, resource_id ] }
-              uplink_ls_id: { get_attribute: [ master_lswith, resource_id ] }
-              uplink_ip: 192.168.1.11
-              uplink_subnet: 255.255.255.0
-              uplink_dgw: 192.168.1.1
-    relationships:
-      - type: cloudify.relationships.connected_to
-        target: master_lswith
-      - type: cloudify.nsx.relationships.deployed_on_datacenter
-        target: datacenter
-      - type: cloudify.nsx.relationships.deployed_on_datastore
-        target: datastore
-      - type: cloudify.nsx.relationships.deployed_on_cluster
-        target: cluster
-
-  interface:
-    type: cloudify.nsx.dlr_interface
-    properties:
-      nsx_auth: *nsx_auth
+      interface:
+        ifindex: 3
+        ipaddr: 192.168.3.1
+        netmask: 255.255.255.0
+        prefixlen: 24
+        name: {concat:[{get_input: node_name_prefix}, router_interface]}
+        mtu: 1500
+        is_connected: true
+        vnic_type: uplink
+        enable_send_redirects: true
+        enable_proxy_arp: true
+        secondary_ips: 192.168.3.128
     interfaces:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
             interface:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              interface_ls_id: { get_attribute: [ slave_lswith, resource_id ] }
-              interface_ip: 192.168.2.11
-              interface_subnet: 255.255.255.0
-              name: {concat:[{get_input: node_name_prefix}, router_interface]}
+              esg_id: { get_attribute: [ esg, resource_id ] }
+              portgroup_id: { get_attribute: [ slave_lswith, resource_id ] }
     relationships:
       - type: cloudify.relationships.contained_in
-        target: nsx_dlr
+        target: esg
       - type: cloudify.relationships.connected_to
         target: slave_lswith
+
+  esg_gateway:
+    type: cloudify.nsx.esg_gateway
+    properties:
+      nsx_auth: *nsx_auth
+      gateway:
+        dgw_ip: 192.168.3.11
+        vnic: 3
+        mtu: 1500
+        admin_distance: 1
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            gateway:
+              esg_id: { get_attribute: [ esg, resource_id ] }
+    relationships:
+      - type: cloudify.relationships.contained_in
+        target: esg
+      - type: cloudify.relationships.connected_to
+        target: esg_interface
+
+  esg_reconfigure:
+    type: cloudify.nsx.esg
+    properties:
+      nsx_auth: *nsx_auth
+      use_external_resource: true
+      routing:
+        enabled: true
+        routingGlobalConfig:
+          routerId: 192.168.3.11
+          logging:
+            logLevel: info
+            enable: false
+          ecmp: false
+      ospf:
+        enabled: true
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            resource_id: { get_attribute: [ esg, resource_id ] }
+        delete:
+          inputs:
+            routing:
+              enabled: true
+              routingGlobalConfig:
+                routerId: ""
+                logging:
+                  logLevel: info
+                  enable: false
+                ecmp: false
+    relationships:
+      # we need interface before change routering
+      - type: cloudify.relationships.depends_on
+        target: esg_gateway
 
   ospf_areas:
     type: cloudify.nsx.ospf_areas
@@ -225,16 +272,16 @@ node_templates:
         create:
           inputs:
             area:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
+              dlr_id: { get_attribute: [ esg_reconfigure, resource_id ] }
               areaId: 1000
               type: nssa
               authentication:
                 type: none
     relationships:
       - type: cloudify.relationships.contained_in
-        target: nsx_dlr
-      - type: cloudify.relationships.connected_to
-        target: interface
+        target: esg_reconfigure
+      - type: cloudify.relationships.depends_on
+        target: esg_interface
 
   ospf_interface:
     type: cloudify.nsx.ospf_interfaces
@@ -245,8 +292,8 @@ node_templates:
         create:
           inputs:
             interface:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              vnic: { get_attribute: [ nsx_dlr, router, uplink_vnic ] }
+              dlr_id: { get_attribute: [ esg_reconfigure, resource_id ] }
+              vnic: { get_attribute: [ esg_interface, resource_id ] }
               areaId: { get_attribute: [ ospf_areas, area, areaId ] }
               helloInterval: 10
               priority: 128
@@ -256,63 +303,7 @@ node_templates:
     relationships:
       - type: cloudify.relationships.connected_to
         target: ospf_areas
-      - type: cloudify.relationships.connected_to
-        target: interface
+      - type: cloudify.relationships.depends_on
+        target: esg_interface
       - type: cloudify.relationships.contained_in
-        target: nsx_dlr
-
-  dlr_static_gateway:
-    type: cloudify.nsx.dlr_dgw
-    properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            gateway:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              address: 192.168.1.12
-    relationships:
-      - type: cloudify.relationships.contained_in
-        target: nsx_dlr
-
-  dhcp_relay:
-    type: cloudify.nsx.dlr_dhcp_relay
-    properties:
-      nsx_auth: *nsx_auth
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        create:
-          inputs:
-            relay:
-              dlr_id: { get_attribute: [ nsx_dlr, resource_id ] }
-              relayServer:
-                ipAddress: 8.8.8.8
-              relayAgents:
-                relayAgent:
-                  vnicIndex: { get_attribute: [ interface, resource_id ] }
-                  giAddress: { get_attribute: [ interface, interface, interface_ip ] }
-    relationships:
-      - type: cloudify.relationships.contained_in
-        target: nsx_dlr
-      - type: cloudify.relationships.connected_to
-        target: interface
-
-  testserver:
-    type: cloudify.vsphere.nodes.Server
-    properties:
-      install_agent: false
-      server:
-        name: {concat:[{get_input: node_name_prefix}, connecttonsxnet]}
-        template: { get_input: template_name }
-        cpus: 1
-        memory: 2048
-      connection_config: { get_property: [connection_configuration, connection_config] }
-      networking:
-        connect_networks:
-          - name: slave_lswith
-            from_relationship: true
-            switch_distributed: true
-    relationships:
-      - target: slave_lswith
-        type: cloudify.relationships.connected_to
+        target: esg

--- a/tests/integration/resources/security_functionality.yaml
+++ b/tests/integration/resources/security_functionality.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - ../plugin.yaml
+  - ../../../plugin.yaml
   - https://raw.githubusercontent.com/cloudify-cosmo/cloudify-vsphere-plugin/2.3.0-m1/plugin.yaml
 
 inputs:
@@ -67,6 +67,11 @@ inputs:
        vcenter datacenter
     default: Datacenter
 
+  vcenter_resource_pool:
+    description: >
+      Resource pool name
+    default: Resources
+
   template_name:
     description: >
       Template to clone VMs from
@@ -88,7 +93,7 @@ node_templates:
         host: { get_input: vcenter_ip }
         port: 443
         datacenter_name: { get_input: vcenter_datacenter }
-        resource_pool_name: Resources
+        resource_pool_name: { get_input: vcenter_resource_pool }
         auto_placement: true
 
   slave_security_group:

--- a/tests/integration/test_comulative.py
+++ b/tests/integration/test_comulative.py
@@ -1,0 +1,198 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+# Stdlib imports
+import os
+
+# Third party imports
+import unittest
+import pytest
+
+# Cloudify imports
+from cloudify.workflows import local
+from cloudify_cli import constants as cli_constants
+
+
+class ComulativeTest(unittest.TestCase):
+
+    def setUp(self):
+        super(ComulativeTest, self).setUp()
+        self.comulative_env = None
+        self.ext_inputs = {
+            # prefix for run
+            'node_name_prefix': os.environ.get('NODE_NAME_PREFIX', ""),
+            # nsx inputs
+            'nsx_ip': os.environ.get('NSX_IP'),
+            'nsx_user': os.environ.get('NSX_USER'),
+            'nsx_password': os.environ.get('NSX_PASSWORD'),
+            # vcenter inputs
+            'vcenter_ip': os.environ.get('VCENTER_IP'),
+            'vcenter_user': os.environ.get('VCENTER_USER'),
+            'vcenter_password': os.environ.get('VCENTER_PASSWORD')
+        }
+
+        if (
+            not self.ext_inputs['nsx_ip'] or
+            not self.ext_inputs['nsx_ip'] or
+            not self.ext_inputs['nsx_password']
+        ):
+                self.skipTest("You dont have credentials for nsx")
+
+        if (
+            not self.ext_inputs['vcenter_ip'] or
+            not self.ext_inputs['vcenter_ip'] or
+            not self.ext_inputs['vcenter_password']
+        ):
+                self.skipTest("You dont have credentials for vcenter")
+
+        blueprints_path = os.path.split(os.path.abspath(__file__))[0]
+        self.blueprints_path = os.path.join(
+            blueprints_path,
+            'resources'
+        )
+
+    def tearDown(self):
+        if self.comulative_env:
+            try:
+                self.comulative_env.execute(
+                    'uninstall',
+                    task_retries=50,
+                    task_retry_interval=3,
+                )
+            except Exception as ex:
+                print str(ex)
+        super(ComulativeTest, self).tearDown()
+
+    def _common_run(self, name, inputs):
+        # set blueprint name
+        blueprint = os.path.join(
+            self.blueprints_path,
+            name
+        )
+
+        # cfy local init
+        self.comulative_env = local.init_env(
+            blueprint,
+            inputs=inputs,
+            name=self._testMethodName,
+            ignored_modules=cli_constants.IGNORED_LOCAL_WORKFLOW_MODULES)
+
+        # cfy local execute -w install
+        self.comulative_env.execute(
+            'install',
+            task_retries=50,
+            task_retry_interval=3,
+        )
+
+        # cfy local execute -w uninstall
+        self.comulative_env.execute(
+            'uninstall',
+            task_retries=50,
+            task_retry_interval=3,
+        )
+
+        self.comulative_env = None
+
+    @pytest.mark.external
+    def test_securitytag(self):
+        """Dry run: Check security tag functionality"""
+        inputs = {k: self.ext_inputs[k] for k in self.ext_inputs}
+
+        if os.environ.get('VCENTER_DATASTORE'):
+            inputs['vcenter_datastore'] = os.environ.get('VCENTER_DATASTORE')
+        if os.environ.get('VCENTER_DATACENTER'):
+            inputs['vcenter_datacenter'] = os.environ.get('VCENTER_DATACENTER')
+        if os.environ.get('VCENTER_TEMPLATE'):
+            inputs['template_name'] = os.environ.get('VCENTER_TEMPLATE')
+
+        self._common_run('security_functionality.yaml', inputs)
+
+    @pytest.mark.external
+    def test_dlr(self):
+        """Dry run: Check dlr functionality"""
+        inputs = {k: self.ext_inputs[k] for k in self.ext_inputs}
+
+        if os.environ.get('VCENTER_CLUSTER'):
+            inputs['vcenter_cluster'] = os.environ.get('VCENTER_CLUSTER')
+        if os.environ.get('VCENTER_DATASTORE'):
+            inputs['vcenter_datastore'] = os.environ.get('VCENTER_DATASTORE')
+        if os.environ.get('VCENTER_DATACENTER'):
+            inputs['vcenter_datacenter'] = os.environ.get('VCENTER_DATACENTER')
+        if os.environ.get('VCENTER_RESOURCE_POOL'):
+            inputs['vcenter_resource_pool'] = os.environ.get(
+                'VCENTER_RESOURCE_POOL'
+            )
+        if os.environ.get('VCENTER_TEMPLATE'):
+            inputs['template_name'] = os.environ.get('VCENTER_TEMPLATE')
+
+        self._common_run('dlr_functionality.yaml', inputs)
+
+    @pytest.mark.external
+    def test_dlr_bgp(self):
+        """Dry run: Check dlr with bgp routing functionality"""
+        inputs = {k: self.ext_inputs[k] for k in self.ext_inputs}
+
+        if os.environ.get('VCENTER_CLUSTER'):
+            inputs['vcenter_cluster'] = os.environ.get('VCENTER_CLUSTER')
+        if os.environ.get('VCENTER_DATASTORE'):
+            inputs['vcenter_datastore'] = os.environ.get('VCENTER_DATASTORE')
+        if os.environ.get('VCENTER_DATACENTER'):
+            inputs['vcenter_datacenter'] = os.environ.get('VCENTER_DATACENTER')
+        if os.environ.get('VCENTER_RESOURCE_POOL'):
+            inputs['vcenter_resource_pool'] = os.environ.get(
+                'VCENTER_RESOURCE_POOL'
+            )
+
+        self._common_run('dlr_with_bgp_functionality.yaml', inputs)
+
+    @pytest.mark.external
+    def test_esg(self):
+        """Dry run: Check edge gateway functionality"""
+        inputs = {k: self.ext_inputs[k] for k in self.ext_inputs}
+
+        if os.environ.get('VCENTER_CLUSTER'):
+            inputs['vcenter_cluster'] = os.environ.get('VCENTER_CLUSTER')
+        if os.environ.get('VCENTER_DATASTORE'):
+            inputs['vcenter_datastore'] = os.environ.get('VCENTER_DATASTORE')
+        if os.environ.get('VCENTER_DATACENTER'):
+            inputs['vcenter_datacenter'] = os.environ.get('VCENTER_DATACENTER')
+        if os.environ.get('VCENTER_RESOURCE_POOL'):
+            inputs['vcenter_resource_pool'] = os.environ.get(
+                'VCENTER_RESOURCE_POOL'
+            )
+
+        self._common_run('esg_functionality.yaml', inputs)
+
+    @pytest.mark.external
+    def test_esg_ospf(self):
+        """Dry run: Check edge gateway with ospf routing functionality"""
+        inputs = {k: self.ext_inputs[k] for k in self.ext_inputs}
+
+        if os.environ.get('VCENTER_CLUSTER'):
+            inputs['vcenter_cluster'] = os.environ.get('VCENTER_CLUSTER')
+        if os.environ.get('VCENTER_DATASTORE'):
+            inputs['vcenter_datastore'] = os.environ.get('VCENTER_DATASTORE')
+        if os.environ.get('VCENTER_DATACENTER'):
+            inputs['vcenter_datacenter'] = os.environ.get('VCENTER_DATACENTER')
+        if os.environ.get('VCENTER_RESOURCE_POOL'):
+            inputs['vcenter_resource_pool'] = os.environ.get(
+                'VCENTER_RESOURCE_POOL'
+            )
+
+        self._common_run('esg_with_ospf_functionality.yaml', inputs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_comulative.py
+++ b/tests/integration/test_comulative.py
@@ -68,8 +68,8 @@ class ComulativeTest(unittest.TestCase):
             try:
                 self.comulative_env.execute(
                     'uninstall',
-                    task_retries=50,
-                    task_retry_interval=3,
+                    task_retries=5,
+                    task_retry_interval=30,
                 )
             except Exception as ex:
                 print str(ex)
@@ -92,15 +92,15 @@ class ComulativeTest(unittest.TestCase):
         # cfy local execute -w install
         self.comulative_env.execute(
             'install',
-            task_retries=50,
-            task_retry_interval=3,
+            task_retries=5,
+            task_retry_interval=30,
         )
 
         # cfy local execute -w uninstall
         self.comulative_env.execute(
             'uninstall',
-            task_retries=50,
-            task_retry_interval=3,
+            task_retries=5,
+            task_retry_interval=30,
         )
 
         self.comulative_env = None

--- a/tests/unittests/library/test_nsx_common.py
+++ b/tests/unittests/library/test_nsx_common.py
@@ -298,6 +298,70 @@ class NsxCommonTest(unittest.TestCase):
             43
         )
 
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_get_properties_public(self):
+        """Check nsx_common.get_properties func"""
+        self._regen_ctx()
+        self.assertEqual(
+            common.get_properties('some_name', {'some_name': {
+                'somevalue': True
+            }}),
+            (False, {'somevalue': True})
+        )
+        self._regen_ctx()
+        self.fake_ctx.node.properties['use_external_resource'] = True
+        self.assertEqual(
+            common.get_properties('some_name', {'some_name': {
+                'somevalue': False
+            }}),
+            (True, {'somevalue': False})
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_get_properties_and_validate(self):
+        """Check nsx_common.get_properties_and_validate func"""
+        self._regen_ctx()
+        self.assertEqual(
+            common.get_properties_and_validate('some_name', {'some_name': {
+                'somevalue': True,
+                'not_showed': 'really'
+            }}, {'somevalue': {'type': 'boolean'}}),
+            (False, {'somevalue': True})
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_check_raw_result(self):
+        """Check nsx_common.check_raw_result func"""
+        self._regen_ctx()
+        # common response on successful result
+        common.check_raw_result({'status': 204})
+        # check other posible successful results
+        for i in xrange(200, 299):
+            common.check_raw_result({'status': i})
+
+        with self.assertRaises(cfy_exc.NonRecoverableError):
+            common.check_raw_result({'status': 199})
+
+        with self.assertRaises(cfy_exc.NonRecoverableError):
+            common.check_raw_result({'status': 300})
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_remove_properties(self):
+        """Check nsx_common.remove_properties func"""
+        self._regen_ctx()
+        self.fake_ctx.instance.runtime_properties['resource_id'] = '1'
+        self.fake_ctx.instance.runtime_properties['resource'] = '2'
+        self.fake_ctx.instance.runtime_properties['not_resource'] = '3'
+        common.remove_properties('resource')
+        self.assertEqual(
+            self.fake_ctx.instance.runtime_properties,
+            {'not_resource': '3'}
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_esg.py
+++ b/tests/unittests/network/test_esg.py
@@ -70,7 +70,7 @@ class EsgTest(unittest.TestCase):
                                          'password': 'password',
                                          'host': 'host'})
         fake_dlr_esg.update_common_edges.assert_called_with(
-            fake_client,  'some_id', {
+            fake_client, 'some_id', {
                 'nsx_auth': {
                     'username': 'username',
                     'host': 'host',

--- a/tests/unittests/network/test_lswitch.py
+++ b/tests/unittests/network/test_lswitch.py
@@ -57,7 +57,7 @@ class LswitchTest(unittest.TestCase):
             mock.MagicMock(return_value=fake_client)
         ):
             with mock.patch(
-                'cloudify_nsx.library.nsx_common.get_logical_switch',
+                'cloudify_nsx.library.nsx_lswitch.get_logical_switch',
                 fake_get_logical_switch
             ):
                 lswitch.create(ctx=self.fake_ctx,

--- a/tests/unittests/security/test_group_exclude_member.py
+++ b/tests/unittests/security/test_group_exclude_member.py
@@ -66,5 +66,6 @@ class SecurityGroupExcludeMemberTest(unittest.TestCase):
             }
         )
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Raise only cfy_exc.RecoverableError in delete action.
* move blueprint_examples to integration tests
* fix error checks
* only show info on delete in case when we don't have some record in routing table or firewall rule table (like deleted automatically on reconfigure)