### PR TITLE
NSX-23,NSX-22: use only resource_id on uninstall

### DIFF
--- a/cloudify_nsx/library/nsx_esg_dlr.py
+++ b/cloudify_nsx/library/nsx_esg_dlr.py
@@ -95,7 +95,13 @@ def dlr_del_interface(client_session, resource_id):
     This function deletes an interface gw to one dlr
     :param resource_id: response from dlr_add_interface
     """
-    ifindex, dlr_id = resource_id.split("|")
+    try:
+        ifindex, dlr_id = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
+
     result_raw = client_session.delete(
         'interfaces', uri_parameters={'edgeId': dlr_id},
         query_parameters_dict={
@@ -403,10 +409,14 @@ def del_edge(client_session, resource_id):
 
 
 def del_bgp_neighbour(client_session, resource_id):
+    try:
+        ids = resource_id.split("|")
 
-    ids = resource_id.split("|")
-
-    esg_id, ipAddress, remoteAS, protocolAddress, forwardingAddress = ids
+        esg_id, ipAddress, remoteAS, protocolAddress, forwardingAddress = ids
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     current_bgp = common.nsx_read(
         client_session, 'body',
@@ -565,7 +575,10 @@ def add_bgp_neighbour_filter(client_session, use_existing, neighbour_id,
 
 def del_bgp_neighbour_filter(client_session, resource_id):
     ids = resource_id.split("|")
-
+    if len(ids) != 6:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID'
+        )
     network = ids[0]
     esg_id = ids[1]
     ipAddress = ids[2]
@@ -820,8 +833,12 @@ def add_esg_ospf_interface(client_session, esg_id, area_id, vnic, use_existing,
 
 
 def del_esg_ospf_area(client_session, resource_id):
-
-    esg_id, area_id = resource_id.split("|")
+    try:
+        esg_id, area_id = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     raw_result = client_session.read(
         'routingOSPF', uri_parameters={'edgeId': esg_id})
@@ -855,8 +872,12 @@ def del_esg_ospf_area(client_session, resource_id):
 
 
 def del_esg_ospf_interface(client_session, resource_id):
-
-    esg_id, area_id, vnic = resource_id.split("|")
+    try:
+        esg_id, area_id, vnic = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     raw_result = client_session.read(
         'routingOSPF', uri_parameters={'edgeId': esg_id})
@@ -972,7 +993,12 @@ def esg_clear_interface(client_session, resource_id):
     :param resource_id: response from esg_cfg_interface
     :return: Returns True on successful configuration of the Interface
     """
-    ifindex, esg_id = resource_id.split("|")
+    try:
+        ifindex, esg_id = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     vnic_config = client_session.read(
         'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id}
@@ -1310,8 +1336,12 @@ def add_routing_prefix(client_session, use_existing, esg_id, name, ipAddress):
 
 
 def del_routing_prefix(client_session, resource_id):
-
-    esg_id, name = resource_id.split("|")
+    try:
+        esg_id, name = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     raw_result = client_session.read(
         'routingConfig', uri_parameters={'edgeId': str(esg_id)})
@@ -1447,8 +1477,12 @@ def add_routing_rule(client_session, use_existing, esg_id, routing_type,
 
 
 def del_routing_rule(client_session, resource_id):
-
-    esg_id, routing_type, prefixName = resource_id.split("|")
+    try:
+        esg_id, routing_type, prefixName = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     raw_result = client_session.read(
         'routingConfig', uri_parameters={'edgeId': str(esg_id)})
@@ -1517,8 +1551,12 @@ def esg_dgw_clear(client_session, resource_id):
     :param resource_id: response from esg_dgw_set
     :return: True on success, False on failure
     """
-
-    esg_id, _ = resource_id.split("|")
+    try:
+        esg_id, _ = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     rtg_cfg = client_session.read(
         'routingConfigStatic', uri_parameters={'edgeId': esg_id}
@@ -1623,8 +1661,12 @@ def esg_route_del(client_session, resource_id):
     :param resource_id: response from esg_route_add
     :return: True on success, False on failure
     """
-
-    esg_id, network, next_hop = resource_id.split("|")
+    try:
+        esg_id, network, next_hop = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     rtg_cfg = client_session.read(
         'routingConfigStatic', uri_parameters={'edgeId': esg_id}
@@ -1727,8 +1769,12 @@ def delete_dhcp_pool(client_session, resource_id):
     :return: Returns None if Edge was not found or the operation failed,
         returns true on success
     """
-
-    esg_id, pool_id = resource_id.split("|")
+    try:
+        esg_id, pool_id = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     result = client_session.delete(
         'dhcpPoolID', uri_parameters={'edgeId': esg_id, 'poolID': pool_id})
@@ -1866,8 +1912,12 @@ def delete_dhcp_binding(client_session, resource_id):
     :return: Returns None if Edge was not found or the operation failed,
         returns true on success
     """
-
-    esg_id, bindingID = resource_id.split("|")
+    try:
+        esg_id, bindingID = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
 
     result = client_session.delete(
         'dhcpStaticBindingID',

--- a/cloudify_nsx/library/nsx_esg_dlr.py
+++ b/cloudify_nsx/library/nsx_esg_dlr.py
@@ -49,13 +49,16 @@ def dlr_add_interface(client_session, dlr_id, interface_ls_id, interface_ip,
     interface['name'] = name
     interface['index'] = vnic
 
-    dlr_interface = client_session.create(
+    result_raw = client_session.create(
         'interfaces', uri_parameters={'edgeId': dlr_id},
         query_parameters_dict={'action': "patch"},
         request_body_dict=dlr_interface_dict
     )
-    common.check_raw_result(dlr_interface)
-    return dlr_interface
+    common.check_raw_result(result_raw)
+    ifindex = result_raw['body']['interfaces']['interface']['index']
+    resource_id = "%s|%s" % (ifindex, dlr_id)
+
+    return ifindex, resource_id
 
 
 def esg_fw_default_set(client_session, esg_id, def_action,
@@ -87,16 +90,16 @@ def esg_fw_default_set(client_session, esg_id, def_action,
     common.check_raw_result(cfg_result)
 
 
-def dlr_del_interface(client_session, dlr_id, resource_id):
+def dlr_del_interface(client_session, resource_id):
     """
     This function deletes an interface gw to one dlr
-    :param dlr_id: dlr uuid
-    :param resource_id: dlr interface id
+    :param resource_id: response from dlr_add_interface
     """
+    ifindex, dlr_id = resource_id.split("|")
     result_raw = client_session.delete(
         'interfaces', uri_parameters={'edgeId': dlr_id},
         query_parameters_dict={
-            'index': resource_id
+            'index': ifindex
         })
     common.check_raw_result(result_raw)
 
@@ -958,24 +961,26 @@ def esg_cfg_interface(client_session, esg_id, ifindex, ipaddr=None,
         'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id},
         request_body_dict=vnic_config)
     common.check_raw_result(cfg_result)
+    return ifindex, "%s|%s" % (ifindex, esg_id)
 
 
-def esg_clear_interface(client_session, esg_id, resource_id):
+def esg_clear_interface(client_session, resource_id):
     """
     This function resets the vnic configuration of an ESG to its default
       state
     :param client_session: An instance of an NsxClient Session
-    :param esg_id: esg uuid
-    :param ifindex: The vnic index, e.g. vnic3 and the index 3
+    :param resource_id: response from esg_cfg_interface
     :return: Returns True on successful configuration of the Interface
     """
+    ifindex, esg_id = resource_id.split("|")
+
     vnic_config = client_session.read(
-        'vnic', uri_parameters={'index': resource_id, 'edgeId': esg_id}
+        'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id}
     )['body']
 
     vnic_config['vnic']['mtu'] = '1500'
     vnic_config['vnic']['type'] = 'internal'
-    vnic_config['vnic']['name'] = 'vnic{}'.format(resource_id)
+    vnic_config['vnic']['name'] = 'vnic{}'.format(ifindex)
     vnic_config['vnic']['addressGroups'] = None
     vnic_config['vnic']['portgroupId'] = None
     vnic_config['vnic']['portgroupName'] = None
@@ -984,7 +989,7 @@ def esg_clear_interface(client_session, esg_id, resource_id):
     vnic_config['vnic']['isConnected'] = 'false'
 
     cfg_result = client_session.update(
-        'vnic', uri_parameters={'index': resource_id, 'edgeId': esg_id},
+        'vnic', uri_parameters={'index': ifindex, 'edgeId': esg_id},
         request_body_dict=vnic_config)
     common.check_raw_result(cfg_result)
 
@@ -1505,13 +1510,15 @@ def del_routing_rule(client_session, resource_id):
     common.check_raw_result(raw_result)
 
 
-def esg_dgw_clear(client_session, esg_id):
+def esg_dgw_clear(client_session, resource_id):
     """
     This function clears the default gateway config on an ESG
     :param client_session: An instance of an NsxClient Session
-    :param esg_id: The id of the ESG to list interfaces of
+    :param resource_id: response from esg_dgw_set
     :return: True on success, False on failure
     """
+
+    esg_id, _ = resource_id.split("|")
 
     rtg_cfg = client_session.read(
         'routingConfigStatic', uri_parameters={'edgeId': esg_id}
@@ -1557,6 +1564,7 @@ def esg_dgw_set(client_session, esg_id, dgw_ip, vnic, mtu=None,
         request_body_dict=rtg_cfg
     )
     common.check_raw_result(cfg_result)
+    return "%s|%s" % (esg_id, dgw_ip)
 
 
 def esg_route_add(client_session, esg_id, network, next_hop, vnic=None,
@@ -1605,17 +1613,18 @@ def esg_route_add(client_session, esg_id, network, next_hop, vnic=None,
 
     common.check_raw_result(cfg_result)
 
+    return "%s|%s|%s" % (esg_id, network, next_hop)
 
-def esg_route_del(client_session, esg_id, network, next_hop):
+
+def esg_route_del(client_session, resource_id):
     """
     This function deletes a static route to an ESG
     :param client_session: An instance of an NsxClient Session
-    :param esg_id: The id of the ESG where the route should be deleted
-    :param network: The routes network in the x.x.x.x/yy format,
-        e.g. 192.168.1.0/24
-    :param next_hop: The next hop ip
+    :param resource_id: response from esg_route_add
     :return: True on success, False on failure
     """
+
+    esg_id, network, next_hop = resource_id.split("|")
 
     rtg_cfg = client_session.read(
         'routingConfigStatic', uri_parameters={'edgeId': esg_id}
@@ -1701,10 +1710,10 @@ def add_dhcp_pool(client_session, esg_id, ip_range, default_gateway=None,
 
     common.check_raw_result(result)
 
-    return result['objectId']
+    return "%s|%s" % (esg_id, result['objectId'])
 
 
-def delete_dhcp_pool(client_session, esg_id, pool_id):
+def delete_dhcp_pool(client_session, resource_id):
     """
     This function deletes a DHCP Pools from an edge DHCP Server
 
@@ -1718,6 +1727,8 @@ def delete_dhcp_pool(client_session, esg_id, pool_id):
     :return: Returns None if Edge was not found or the operation failed,
         returns true on success
     """
+
+    esg_id, pool_id = resource_id.split("|")
 
     result = client_session.delete(
         'dhcpPoolID', uri_parameters={'edgeId': esg_id, 'poolID': pool_id})
@@ -1778,7 +1789,7 @@ def add_mac_binding(client_session, esg_id, mac, hostname, ip,
         request_body_dict={'staticBinding': binding_dict}
     )
     common.check_raw_result(result)
-    return result['objectId']
+    return "%s|%s" % (esg_id, result['objectId'])
 
 
 def add_vm_binding(client_session, esg_id, vm_id, vnic_id, hostname, ip,
@@ -1838,10 +1849,10 @@ def add_vm_binding(client_session, esg_id, vm_id, vnic_id, hostname, ip,
         request_body_dict={'staticBinding': binding_dict}
     )
     common.check_raw_result(result)
-    return result['objectId']
+    return "%s|%s" % (esg_id, result['objectId'])
 
 
-def delete_dhcp_binding(client_session, esg_id, resource_id):
+def delete_dhcp_binding(client_session, resource_id):
     """
     This function deletes a DHCP binding from an edge DHCP Server
 
@@ -1856,9 +1867,11 @@ def delete_dhcp_binding(client_session, esg_id, resource_id):
         returns true on success
     """
 
+    esg_id, bindingID = resource_id.split("|")
+
     result = client_session.delete(
         'dhcpStaticBindingID',
-        uri_parameters={'edgeId': esg_id, 'bindingID': resource_id}
+        uri_parameters={'edgeId': esg_id, 'bindingID': bindingID}
     )
 
     common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_firewall.py
+++ b/cloudify_nsx/library/nsx_firewall.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import nsx_common as common
+from cloudify import exceptions as cfy_exc
 
 
 def add_firewall_rule(client_session, esg_id, application='any',
@@ -67,7 +68,13 @@ def add_firewall_rule(client_session, esg_id, application='any',
 def delete_firewall_rule(client_session, resource_id):
     """Delete firewall rule, as resource_id used response
        from add_firewall_rule"""
-    esg_id, rule_id = resource_id.split("|")
+    try:
+        esg_id, rule_id = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
+
     result = client_session.delete(
         'firewallRule', uri_parameters={
             'edgeId': esg_id, 'ruleId': rule_id

--- a/cloudify_nsx/library/nsx_firewall.py
+++ b/cloudify_nsx/library/nsx_firewall.py
@@ -61,13 +61,16 @@ def add_firewall_rule(client_session, esg_id, application='any',
 
     common.check_raw_result(result_raw)
 
-    return result_raw['objectId']
+    return result_raw['objectId'], "%s|%s" % (esg_id, result_raw['objectId'])
 
 
-def delete_firewall_rule(client_session, esg_id, resource_id):
+def delete_firewall_rule(client_session, resource_id):
+    """Delete firewall rule, as resource_id used response
+       from add_firewall_rule"""
+    esg_id, rule_id = resource_id.split("|")
     result = client_session.delete(
         'firewallRule', uri_parameters={
-            'edgeId': esg_id, 'ruleId': resource_id
+            'edgeId': esg_id, 'ruleId': rule_id
         })
 
     common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_nat.py
+++ b/cloudify_nsx/library/nsx_nat.py
@@ -78,11 +78,12 @@ def add_nat_rule(client_session, esg_id, action, originalAddress,
 
     common.check_raw_result(result_raw)
 
-    return result_raw['objectId']
+    return "%s|%s" % (esg_id, result_raw['objectId'])
 
 
-def delete_nat_rule(client_session, esg_id, resource_id):
+def delete_nat_rule(client_session, resource_id):
+    esg_id, ruleID = resource_id.split("|")
     result = client_session.delete(
-        'edgeNatRule', uri_parameters={'edgeId': esg_id, 'ruleID': resource_id}
+        'edgeNatRule', uri_parameters={'edgeId': esg_id, 'ruleID': ruleID}
     )
     common.check_raw_result(result)

--- a/cloudify_nsx/library/nsx_nat.py
+++ b/cloudify_nsx/library/nsx_nat.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import nsx_common as common
+from cloudify import exceptions as cfy_exc
 
 
 def nat_service(client_session, esg_id, enabled):
@@ -82,7 +83,12 @@ def add_nat_rule(client_session, esg_id, action, originalAddress,
 
 
 def delete_nat_rule(client_session, resource_id):
-    esg_id, ruleID = resource_id.split("|")
+    try:
+        esg_id, ruleID = resource_id.split("|")
+    except Exception as ex:
+        raise cfy_exc.NonRecoverableError(
+            'Unexpected error retrieving resource ID: %s' % str(ex)
+        )
     result = client_session.delete(
         'edgeNatRule', uri_parameters={'edgeId': esg_id, 'ruleID': ruleID}
     )

--- a/cloudify_nsx/network/dhcp_bind.py
+++ b/cloudify_nsx/network/dhcp_bind.py
@@ -138,7 +138,6 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_dhcp.delete_dhcp_binding,
         client_session=client_session,
-        esg_id=bind_dict['esg_id'],
         resource_id=resource_id
     )
 

--- a/cloudify_nsx/network/dhcp_pool.py
+++ b/cloudify_nsx/network/dhcp_pool.py
@@ -103,8 +103,7 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_dhcp.delete_dhcp_pool,
         client_session=client_session,
-        esg_id=pool_dict['esg_id'],
-        pool_id=resource_id
+        resource_id=resource_id
     )
 
     ctx.logger.info("deleted %s" % resource_id)

--- a/cloudify_nsx/network/esg_firewall.py
+++ b/cloudify_nsx/network/esg_firewall.py
@@ -84,7 +84,7 @@ def create(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    resource_id = nsx_firewall.add_firewall_rule(
+    rule_id, resource_id = nsx_firewall.add_firewall_rule(
         client_session,
         firewall_dict['esg_id'],
         firewall_dict['application'],
@@ -106,34 +106,13 @@ def create(**kwargs):
         )
 
     ctx.instance.runtime_properties['resource_id'] = resource_id
+    ctx.instance.runtime_properties['rule_id'] = rule_id
     ctx.logger.info("created %s" % resource_id)
 
 
 @operation
 def delete(**kwargs):
-    use_existing, nat_dict = common.get_properties('rule', kwargs)
-
-    if use_existing:
-        common.remove_properties('rule')
-        ctx.logger.info("Used existed")
-        return
-
-    resource_id = ctx.instance.runtime_properties.get('resource_id')
-    if not resource_id:
-        common.remove_properties('rule')
-        ctx.logger.info("Not fully created, skip")
-        return
-
-    # credentials
-    client_session = common.nsx_login(kwargs)
-
-    common.attempt_with_rerun(
-        nsx_firewall.delete_firewall_rule,
-        client_session=client_session,
-        esg_id=nat_dict['esg_id'],
-        resource_id=resource_id
+    common.delete_object(
+        nsx_firewall.delete_firewall_rule, 'rule',
+        kwargs, ['rule_id']
     )
-
-    ctx.logger.info("delete %s" % resource_id)
-
-    common.remove_properties('rule')

--- a/cloudify_nsx/network/esg_gateway.py
+++ b/cloudify_nsx/network/esg_gateway.py
@@ -53,12 +53,10 @@ def create(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    resource_id = gateway['dgw_ip']
-
-    nsx_esg.esg_dgw_set(
+    resource_id = nsx_esg.esg_dgw_set(
         client_session,
         gateway['esg_id'],
-        resource_id,
+        gateway['dgw_ip'],
         gateway['vnic'],
         gateway['mtu'],
         gateway['admin_distance'])
@@ -88,7 +86,7 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_esg.esg_dgw_clear,
         client_session=client_session,
-        esg_id=gateway['esg_id']
+        resource_id=resource_id
     )
 
     ctx.logger.info("delete %s" % resource_id)

--- a/cloudify_nsx/network/esg_interface.py
+++ b/cloudify_nsx/network/esg_interface.py
@@ -79,9 +79,7 @@ def create(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    resource_id = interface['ifindex']
-
-    nsx_esg.esg_cfg_interface(
+    ifindex, resource_id = nsx_esg.esg_cfg_interface(
         client_session,
         interface['esg_id'],
         interface['ifindex'],
@@ -99,6 +97,7 @@ def create(**kwargs):
     )
 
     ctx.instance.runtime_properties['resource_id'] = resource_id
+    ctx.instance.runtime_properties['ifindex'] = ifindex
     ctx.logger.info("created %s" % resource_id)
 
 
@@ -108,12 +107,14 @@ def delete(**kwargs):
 
     if use_existing:
         common.remove_properties('interface')
+        common.remove_properties('ifindex')
         ctx.logger.info("Used existed")
         return
 
     resource_id = ctx.instance.runtime_properties.get('resource_id')
     if not resource_id:
         common.remove_properties('interface')
+        common.remove_properties('ifindex')
         ctx.logger.info("Not fully created, skip")
         return
 
@@ -123,10 +124,10 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_esg.esg_clear_interface,
         client_session=client_session,
-        esg_id=interface['esg_id'],
         resource_id=resource_id
     )
 
     ctx.logger.info("delete %s" % resource_id)
 
     common.remove_properties('interface')
+    common.remove_properties('ifindex')

--- a/cloudify_nsx/network/esg_nat.py
+++ b/cloudify_nsx/network/esg_nat.py
@@ -113,7 +113,6 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_nat.delete_nat_rule,
         client_session=client_session,
-        esg_id=nat_dict['esg_id'],
         resource_id=resource_id
     )
 

--- a/cloudify_nsx/network/esg_route.py
+++ b/cloudify_nsx/network/esg_route.py
@@ -59,13 +59,11 @@ def create(**kwargs):
     # credentials
     client_session = common.nsx_login(kwargs)
 
-    resource_id = route['next_hop']
-
-    nsx_esg.esg_route_add(
+    resource_id = nsx_esg.esg_route_add(
         client_session,
         route['esg_id'],
         route['network'],
-        resource_id,
+        route['next_hop'],
         route['vnic'],
         route['mtu'],
         route['admin_distance'],
@@ -95,9 +93,7 @@ def delete(**kwargs):
     common.attempt_with_rerun(
         nsx_esg.esg_route_del,
         client_session=client_session,
-        esg_id=route['esg_id'],
-        network=route['network'],
-        next_hop=resource_id
+        resource_id=resource_id
     )
 
     ctx.logger.info("delete %s" % resource_id)

--- a/cloudify_nsx/nsx_object.py
+++ b/cloudify_nsx/nsx_object.py
@@ -1,0 +1,86 @@
+########
+# Copyright (c) 2016 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+from cloudify import ctx
+from cloudify.decorators import operation
+import cloudify_nsx.library.nsx_common as common
+import pynsxv.library.nsx_logical_switch as nsx_logical_switch
+import pynsxv.library.nsx_dlr as nsx_router
+import cloudify_nsx.library.nsx_security_group as nsx_security_group
+import cloudify_nsx.library.nsx_security_policy as nsx_security_policy
+import cloudify_nsx.library.nsx_security_tag as nsx_security_tag
+
+
+@operation
+def create(**kwargs):
+    validation_rules = {
+        "name": {
+            "required": True
+        },
+        "type": {
+            "required": True,
+            "values": [
+                'group',
+                'policy',
+                'tag',
+                'lswitch',
+                'router'
+            ]
+        },
+        "scopeId": {
+            "default": "globalroot-0",
+            "required": True
+        }
+    }
+
+    _, nsx_object = common.get_properties_and_validate(
+        'nsx_object', kwargs, validation_rules
+    )
+
+    # credentials
+    client_session = common.nsx_login(kwargs)
+
+    if nsx_object['type'] == 'group':
+        resource_id, _ = nsx_security_group.get_group(
+            client_session,
+            nsx_object['scopeId'],
+            nsx_object['name']
+        )
+    elif nsx_object['type'] == 'policy':
+        resource_id, _ = nsx_security_policy.get_policy(
+            client_session,
+            nsx_object['name']
+        )
+    elif nsx_object['type'] == 'tag':
+        resource_id, _ = nsx_security_tag.get_tag(
+            client_session,
+            nsx_object['name']
+        )
+    elif nsx_object['type'] == 'lswitch':
+        resource_id, switch_params = nsx_logical_switch.logical_switch_read(
+            client_session, nsx_object['name']
+        )
+    elif nsx_object['type'] == 'router':
+        resource_id, _ = nsx_router.dlr_read(
+            client_session, nsx_object['name']
+        )
+
+    runtime_properties = ctx.instance.runtime_properties
+    runtime_properties['resource_id'] = resource_id
+    runtime_properties['use_external_resource'] = resource_id is not None
+
+
+@operation
+def delete(**kwargs):
+    common.remove_properties('nsx_object')

--- a/cloudify_nsx/security/policy.py
+++ b/cloudify_nsx/security/policy.py
@@ -23,7 +23,7 @@ def _update_policy(exist_policy):
     """update policy info by existed policy"""
     for i in ['description', 'precedence', 'parent',
               'securityGroupBinding', 'actionsByCategory']:
-        ctx.instance.runtime_properties['policy'][i] = exist_policy[i]
+        ctx.instance.runtime_properties['policy'][i] = exist_policy.get(i)
 
 
 @operation

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1162,6 +1162,27 @@ node_types:
         delete:
           implementation: nsx.cloudify_nsx.network.dhcp_bind.delete
 
+  # NSX object check
+  cloudify.nsx.nsx_object:
+    derived_from: cloudify.nodes.Root
+    properties:
+      nsx_auth:
+        type: nsx_auth_type
+      nsx_object:
+        default:
+          # name of nsx object to existing check
+          name: ""
+          # type of object
+          type: ""
+          # scope, make sense for group
+          scopeId: "globalroot-0"
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: nsx.cloudify_nsx.nsx_object.create
+        delete:
+          implementation: nsx.cloudify_nsx.nsx_object.delete
+
   # distributed firewall
   cloudify.nsx.dfw_section:
     derived_from: cloudify.nodes.Root

--- a/tests/integration/resources/dlr_functionality.yaml
+++ b/tests/integration/resources/dlr_functionality.yaml
@@ -295,7 +295,7 @@ node_templates:
                 ipAddress: 8.8.8.8
               relayAgents:
                 relayAgent:
-                  vnicIndex: { get_attribute: [ interface, resource_id ] }
+                  vnicIndex: { get_attribute: [ interface, ifindex ] }
                   giAddress: { get_attribute: [ interface, interface, interface_ip ] }
     relationships:
       - type: cloudify.relationships.contained_in

--- a/tests/integration/resources/esg_with_ospf_functionality.yaml
+++ b/tests/integration/resources/esg_with_ospf_functionality.yaml
@@ -228,11 +228,25 @@ node_templates:
       - type: cloudify.relationships.connected_to
         target: esg_interface
 
+  esg_check:
+    type: cloudify.nsx.nsx_object
+    properties:
+      nsx_auth: *nsx_auth
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            nsx_object:
+              name: {concat:[{get_input: node_name_prefix}, real_edge]}
+              type: router
+    relationships:
+      - type: cloudify.relationships.depends_on
+        target: esg
+
   esg_reconfigure:
     type: cloudify.nsx.esg
     properties:
       nsx_auth: *nsx_auth
-      use_external_resource: true
       routing:
         enabled: true
         routingGlobalConfig:
@@ -247,7 +261,8 @@ node_templates:
       cloudify.interfaces.lifecycle:
         create:
           inputs:
-            resource_id: { get_attribute: [ esg, resource_id ] }
+            use_external_resource: { get_attribute: [ esg_check, use_external_resource ] }
+            resource_id: { get_attribute: [ esg_check, resource_id ] }
         delete:
           inputs:
             routing:
@@ -259,6 +274,8 @@ node_templates:
                   enable: false
                 ecmp: false
     relationships:
+      - type: cloudify.relationships.depends_on
+        target: esg_check
       # we need interface before change routering
       - type: cloudify.relationships.depends_on
         target: esg_gateway
@@ -293,7 +310,7 @@ node_templates:
           inputs:
             interface:
               dlr_id: { get_attribute: [ esg_reconfigure, resource_id ] }
-              vnic: { get_attribute: [ esg_interface, resource_id ] }
+              vnic: { get_attribute: [ esg_interface, ifindex ] }
               areaId: { get_attribute: [ ospf_areas, area, areaId ] }
               helloInterval: 10
               priority: 128

--- a/tests/unittests/network/test_dhcp_bind.py
+++ b/tests/unittests/network/test_dhcp_bind.py
@@ -50,24 +50,6 @@ class DhcpBindTest(unittest.TestCase):
                                "hostname": "hostname",
                                "ip": "ip"})
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check remove binding rule vm to dhcp ip"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        dhcp_bind.delete(ctx=self.fake_ctx,
-                         bind={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        dhcp_bind.delete(ctx=self.fake_ctx,
-                         bind={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_dhcp_pool.py
+++ b/tests/unittests/network/test_dhcp_pool.py
@@ -49,24 +49,6 @@ class DhcpPoolTest(unittest.TestCase):
                          pool={"esg_id": "esg_id",
                                "ip_range": "ip_range"})
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check delete dhcp pool"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        dhcp_pool.delete(ctx=self.fake_ctx,
-                         pool={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        dhcp_pool.delete(ctx=self.fake_ctx,
-                         pool={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_dlr_interface.py
+++ b/tests/unittests/network/test_dlr_interface.py
@@ -55,24 +55,6 @@ class DlrInterfaceTest(unittest.TestCase):
             }
         )
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check delete dlr interface"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        dlr_interface.delete(ctx=self.fake_ctx,
-                             interface={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        dlr_interface.delete(ctx=self.fake_ctx,
-                             interface={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_esg_gateway.py
+++ b/tests/unittests/network/test_esg_gateway.py
@@ -48,24 +48,6 @@ class EsgGatewayTest(unittest.TestCase):
         esg_gateway.create(ctx=self.fake_ctx,
                            gateway={"esg_id": "esg_id", "dgw_ip": "dgw_ip"})
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check delete esg gateway"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        esg_gateway.delete(ctx=self.fake_ctx,
-                           gateway={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        esg_gateway.delete(ctx=self.fake_ctx,
-                           gateway={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_esg_interface.py
+++ b/tests/unittests/network/test_esg_interface.py
@@ -49,24 +49,6 @@ class EsgInterfaceTest(unittest.TestCase):
                              interface={"esg_id": "esg_id",
                                         "ifindex": "ifindex"})
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check delete esg interface"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        esg_interface.delete(ctx=self.fake_ctx,
-                             interface={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        esg_interface.delete(ctx=self.fake_ctx,
-                             interface={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/network/test_esg_route.py
+++ b/tests/unittests/network/test_esg_route.py
@@ -48,24 +48,6 @@ class EsgRouteTest(unittest.TestCase):
         esg_route.create(ctx=self.fake_ctx,
                          route={"esg_id": "esg_id", "network": "network"})
 
-    @pytest.mark.internal
-    @pytest.mark.unit
-    def test_uninstall(self):
-        """Check delete esg route"""
-        # not fully created
-        self.fake_ctx.instance.runtime_properties['resource_id'] = None
-        esg_route.delete(ctx=self.fake_ctx,
-                         route={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
-        # check use existed
-        self._regen_ctx()
-        self.fake_ctx.instance.runtime_properties['resource_id'] = 'some_id'
-        self.fake_ctx.node.properties['use_external_resource'] = True
-        esg_route.delete(ctx=self.fake_ctx,
-                         route={})
-        self.assertEqual(self.fake_ctx.instance.runtime_properties, {})
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unittests/test_network_uninstall.py
+++ b/tests/unittests/test_network_uninstall.py
@@ -16,9 +16,15 @@ import library.test_nsx_base as test_nsx_base
 import pytest
 import cloudify_nsx.network.dlr_bgp_neighbour as dlr_bgp_neighbour
 import cloudify_nsx.network.bgp_neighbour_filter as bgp_neighbour_filter
+import cloudify_nsx.network.dhcp_bind as dhcp_bind
+import cloudify_nsx.network.dhcp_pool as dhcp_pool
+import cloudify_nsx.network.dlr_interface as dlr_interface
 import cloudify_nsx.network.esg_firewall as esg_firewall
 import cloudify_nsx.network.lswitch as lswitch
+import cloudify_nsx.network.esg_gateway as esg_gateway
+import cloudify_nsx.network.esg_interface as esg_interface
 import cloudify_nsx.network.esg_nat as esg_nat
+import cloudify_nsx.network.esg_route as esg_route
 from cloudify.state import current_ctx
 
 
@@ -160,16 +166,44 @@ class NetworkUninstallTest(test_nsx_base.NSXBaseTest):
 
     @pytest.mark.internal
     @pytest.mark.unit
-    def test_firewall_rule_uninstall(self):
+    def test_dlr_interface_uninstall(self):
+        """Check delete dlr interface"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|nic_id', dlr_interface.delete,
+            {'interface': {}}
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_dhcp_bind_uninstall(self):
+        """Check remove binding rule vm to dhcp ip"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|bind_id', dhcp_bind.delete,
+            {'bind': {}}
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_dhcp_pool_uninstall(self):
+        """Check delete dhcp pool"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|pool_id', dhcp_pool.delete,
+            {'pool': {}}
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_esg_firewall_rule_uninstall(self):
         """Check delete esg firewall rule"""
         self._common_uninstall_delete(
-            'id', esg_firewall.delete,
+            'esg_id|id', esg_firewall.delete,
             {'rule': {
                 'esg_id': 'esg_id'
             }},
             ['firewallRule'], {
                 'uri_parameters': {'edgeId': 'esg_id', 'ruleId': 'id'}
-            }
+            },
+            additional_params=['rule_id']
         )
 
     @pytest.mark.internal
@@ -187,16 +221,43 @@ class NetworkUninstallTest(test_nsx_base.NSXBaseTest):
 
     @pytest.mark.internal
     @pytest.mark.unit
+    def test_esg_gateway_uninstall(self):
+        """Check delete esg gateway"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|ip', esg_gateway.delete,
+            {'gateway': {}}
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_esg_interface_uninstall(self):
+        """Check delete esg interface"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|id', esg_interface.delete,
+            {'interface': {}}
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
     def test_esg_nat_uninstall(self):
         """Check delete esg nat rule"""
         self._common_uninstall_delete(
-            'id', esg_nat.delete,
+            'esg_id|id', esg_nat.delete,
             {'rule': {
                 'esg_id': 'esg_id'
             }},
             ['edgeNatRule'], {
                 'uri_parameters': {'edgeId': 'esg_id', 'ruleID': 'id'}
             }
+        )
+
+    @pytest.mark.internal
+    @pytest.mark.unit
+    def test_esg_route_uninstall(self):
+        """Check delete esg route"""
+        self._common_uninstall_external_and_unintialized(
+            'esg_id|rule_id|next_hop', esg_route.delete,
+            {'route': {}}
         )
 
 

--- a/tests/unittests/test_security_install.py
+++ b/tests/unittests/test_security_install.py
@@ -47,14 +47,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
             read_kwargs={'uri_parameters': {'scopeId': 'globalroot-0'}},
             read_response={
                 'status': 204,
-                'body': {
-                    'list': {
-                        'securitygroup': {
-                            'name': 'name',
-                            'objectId': 'id'
-                        }
-                    }
-                }
+                'body': test_nsx_base.SEC_GROUP_LIST
             },
             create_args=['secGroupBulk'],
             create_kwargs={
@@ -68,25 +61,22 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                 },
                 'uri_parameters': {'scopeId': 'globalroot-0'}
             },
-            create_response={
-                'status': 204,
-                'objectId': 'id'
-            }
+            create_response=test_nsx_base.SUCCESS_RESPONSE_ID
         )
 
     @pytest.mark.internal
     @pytest.mark.unit
     def test_group_dynamic_member_install(self):
         """Check update dynamic member in security group"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             "security_group_id", group_dynamic_member.create,
             {'dynamic_member': {
                 "dynamic_set": "dynamic_set",
                 "security_group_id": "security_group_id"
             }},
-            ['secGroupObject'],
-            {'uri_parameters': {'objectId': 'security_group_id'}},
-            {
+            read_args=['secGroupObject'],
+            read_kwargs={'uri_parameters': {'objectId': 'security_group_id'}},
+            read_response={
                 'status': 204,
                 'body': {
                     'securitygroup': {
@@ -97,8 +87,8 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                 }
             },
             # for update need to use 'secGroupBulk'
-            ['secGroupBulk'],
-            {
+            update_args=['secGroupBulk'],
+            update_kwargs={
                 'request_body_dict': {
                     'securitygroup': {
                         'dynamicMemberDefinition': {
@@ -110,42 +100,38 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                     'scopeId': 'security_group_id'
                 }
             },
-            {
-                'status': 204
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE
         )
 
     @pytest.mark.internal
     @pytest.mark.unit
     def test_group_exclude_member_install(self):
         """Check insert member to exclude list in security group"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             "security_group_id|member_id", group_exclude_member.create,
             {'group_exclude_member': {
                 "objectId": "member_id",
                 "security_group_id": "security_group_id"
             }},
-            ['secGroupObject'],
-            {'uri_parameters': {'objectId': 'security_group_id'}},
-            {
+            read_args=['secGroupObject'],
+            read_kwargs={'uri_parameters': {'objectId': 'security_group_id'}},
+            read_response={
                 'status': 204,
                 'body': test_nsx_base.SEC_GROUP_EXCLUDE_BEFORE
             },
-            ['secGroupObject'],
-            {
+            update_args=['secGroupObject'],
+            update_kwargs={
                 'request_body_dict': test_nsx_base.SEC_GROUP_EXCLUDE_AFTER,
                 'uri_parameters': {'objectId': 'security_group_id'}
             },
-            {
-                'status': 204
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE
         )
 
     @pytest.mark.internal
     @pytest.mark.unit
     def test_group_member_install(self):
         """Check insert member to include list in security group"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             'security_group_id|objectId', group_member.create,
             {'group_member': {
                 "objectId": "objectId",
@@ -161,10 +147,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                     'objectId': 'security_group_id'
                 }
             },
-            update_response={
-                'status': 204,
-                'objectId': 'id'
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE_ID
         )
 
     @pytest.mark.internal
@@ -182,19 +165,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
             read_kwargs={'uri_parameters': {'ID': 'all'}},
             read_response={
                 'status': 204,
-                'body': {
-                    'securityPolicies': {
-                        'securityPolicy': {
-                            'name': 'name',
-                            'objectId': 'id',
-                            'description': 'description',
-                            'precedence': 'precedence',
-                            'parent': None,
-                            'securityGroupBinding': None,
-                            'actionsByCategory': None
-                        }
-                    }
-                }
+                'body': test_nsx_base.SEC_POLICY_LIST
             },
             create_args=['securityPolicy'],
             create_kwargs={
@@ -209,10 +180,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                     }
                 }
             },
-            create_response={
-                'status': 204,
-                'objectId': 'id'
-            },
+            create_response=test_nsx_base.SUCCESS_RESPONSE_ID,
             recheck_runtime={
                 'policy': {
                     'actionsByCategory': None,
@@ -229,54 +197,50 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
     @pytest.mark.unit
     def test_policy_group_bind_install(self):
         """Check bind security group to security policy"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             "security_group_id|security_policy_id",
             policy_group_bind.create,
             {'policy_group_bind': {
                 "security_policy_id": "security_policy_id",
                 "security_group_id": "security_group_id"
             }},
-            ['securityPolicyID'],
-            {'uri_parameters': {'ID': 'security_policy_id'}},
-            {
+            read_args=['securityPolicyID'],
+            read_kwargs={'uri_parameters': {'ID': 'security_policy_id'}},
+            read_response={
                 'status': 204,
                 'body': test_nsx_base.SEC_GROUP_POLICY_BIND_BEFORE
             },
-            ['securityPolicyID'],
-            {
+            update_args=['securityPolicyID'],
+            update_kwargs={
                 'request_body_dict': test_nsx_base.SEC_GROUP_POLICY_BIND_AFTER,
                 'uri_parameters': {'ID': 'security_policy_id'}
             },
-            {
-                'status': 204
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE
         )
 
     @pytest.mark.internal
     @pytest.mark.unit
     def test_policy_section_install(self):
         """Check replace security policy section"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             "category|security_policy_id", policy_section.create,
             {'policy_section': {
                 "category": "category",
                 "action": "action",
                 "security_policy_id": "security_policy_id"
             }},
-            ['securityPolicyID'],
-            {'uri_parameters': {'ID': 'security_policy_id'}},
-            {
+            read_args=['securityPolicyID'],
+            read_kwargs={'uri_parameters': {'ID': 'security_policy_id'}},
+            read_response={
                 'status': 204,
                 'body': test_nsx_base.SEC_POLICY_SECTION_BEFORE
             },
-            ['securityPolicyID'],
-            {
+            update_args=['securityPolicyID'],
+            update_kwargs={
                 'request_body_dict': test_nsx_base.SEC_POLICY_SECTION_AFTER,
                 'uri_parameters': {'ID': 'security_policy_id'}
             },
-            {
-                'status': 204
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE
         )
 
     @pytest.mark.internal
@@ -292,14 +256,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
             read_kwargs={},
             read_response={
                 'status': 204,
-                'body': {
-                    'securityTags': {
-                        'securityTag': {
-                            'name': 'name',
-                            'objectId': 'id'
-                        }
-                    }
-                }
+                'body': test_nsx_base.SEC_TAG_LIST
             },
             create_args=['securityTag'],
             create_kwargs={
@@ -310,17 +267,14 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                     }
                 }
             },
-            create_response={
-                'status': 204,
-                'objectId': 'id'
-            }
+            create_response=test_nsx_base.SUCCESS_RESPONSE_ID
         )
 
     @pytest.mark.internal
     @pytest.mark.unit
     def test_tag_vm_install(self):
         """Check bind security tag to vm"""
-        self._common_install_read_and_update(
+        self._common_install_extract_or_read_and_update(
             'tag_id|vm_id', tag_vm.create,
             {'vm_tag': {
                 "vm_id": "vm_id", "tag_id": "tag_id"
@@ -335,10 +289,7 @@ class SecurityInstallTest(test_nsx_base.NSXBaseTest):
                     'vmMoid': 'vm_id'
                 }
             },
-            update_response={
-                'status': 204,
-                'objectId': 'id'
-            }
+            update_response=test_nsx_base.SUCCESS_RESPONSE_ID
         )
 
 


### PR DESCRIPTION
NSX-23: refactoring to use only resource_id on delete
NSX-22: fix issue with delete object with use_external_resource in inputs (solved by save use_external_resource in runtime_properties)